### PR TITLE
Do not create an ingress for the worker service

### DIFF
--- a/deployments/server/templates/ingress.yaml
+++ b/deployments/server/templates/ingress.yaml
@@ -42,38 +42,3 @@ spec:
             name: {{ include "inference-manager-server.fullname" . }}-http
             port:
               number: {{ .Values.httpPort }}
-
----
-
-{{- if .Values.global.workerServiceIngress.create -}}
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: {{ include "inference-manager-server.fullname" . }}-worker-service-grpc
-  labels:
-    {{- include "inference-manager-server.labels" . | nindent 4 }}
-  annotations:
-    {{- with .Values.global.workerServiceIngress.annotations }}
-    {{- toYaml . | nindent 4 }}
-    {{- end }}
-spec:
-  ingressClassName: {{ .Values.global.workerServiceIngress.ingressClassName }}
-  {{- with .Values.global.workerServiceIngress.tls }}
-  tls:
-  - hosts:
-      {{- toYaml .hosts | nindent 6 }}
-    {{- if .secretName }}
-    secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
-  rules:
-  - http:
-      paths:
-      - path: /llmoperator.inference.server.v1.InferenceWorkerService
-        pathType: Prefix
-        backend:
-          service:
-            name: {{ include "inference-manager-server.fullname" . }}-worker-service-grpc
-            port:
-              number: {{ .Values.workerServiceGrpcPort }}
-{{- end -}}

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -13,14 +13,6 @@ global:
   workerServiceGrpcService:
     annotations:
 
-  workerServiceIngress:
-    create: false
-    ingressClassName:
-    annotations:
-    tls:
-      hosts:
-      secretName:
-
 httpPort: 8080
 grpcPort: 8081
 workerServiceGrpcPort: 8082


### PR DESCRIPTION
This is never used as inference-manager-engine talks to inference-manager-server without an ingress controller.