### PR TITLE
Refactor the HuggingFace download logic to explicitly take an adapter…

### DIFF
--- a/engine/cmd/pull.go
+++ b/engine/cmd/pull.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"log"
 
-	mv1 "github.com/llmariner/model-manager/api/v1"
 	"github.com/llmariner/inference-manager/engine/internal/config"
 	"github.com/llmariner/inference-manager/engine/internal/modeldownloader"
 	"github.com/llmariner/inference-manager/engine/internal/models"
 	"github.com/llmariner/inference-manager/engine/internal/ollama"
 	"github.com/llmariner/inference-manager/engine/internal/runtime"
 	"github.com/llmariner/inference-manager/engine/internal/s3"
+	mv1 "github.com/llmariner/model-manager/api/v1"
 	"github.com/llmariner/rbac-manager/pkg/auth"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
@@ -118,8 +118,7 @@ func pullBaseModel(
 		return fmt.Errorf("unsupported format: %v", format)
 	}
 
-
-	if err := d.Download(ctx, o.modelID, srcPath, format); err != nil {
+	if err := d.Download(ctx, o.modelID, srcPath, format, mv1.AdapterType_ADAPTER_TYPE_UNSPECIFIED); err != nil {
 		return err
 	}
 
@@ -169,7 +168,7 @@ func pullFineTunedModelForOllama(
 		return err
 	}
 
-	if err := d.DownloadAdapter(ctx, o.modelID, mresp); err != nil {
+	if err := d.DownloadAdapterOfGGUF(ctx, o.modelID, mresp); err != nil {
 		return err
 	}
 
@@ -228,7 +227,7 @@ func pullFineTunedModelForVLLM(
 
 	d := modeldownloader.New(runtime.ModelDir(), s3Client)
 
-	if err := d.Download(ctx, o.modelID, attr.Path, format); err != nil {
+	if err := d.Download(ctx, o.modelID, attr.Path, format, attr.Adapter); err != nil {
 		return err
 	}
 	log.Printf("Successfully pulled the fine-tuning adapter\n")

--- a/engine/internal/modeldownloader/huggingface/download_test.go
+++ b/engine/internal/modeldownloader/huggingface/download_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	mv1 "github.com/llmariner/model-manager/api/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,6 +50,7 @@ func TestDownloadModelFiles(t *testing.T) {
 	tcs := []struct {
 		name            string
 		s3Client        *fakeS3Client
+		adapterType     mv1.AdapterType
 		downloadedFiles []string
 	}{
 		{
@@ -56,6 +58,7 @@ func TestDownloadModelFiles(t *testing.T) {
 			s3Client: &fakeS3Client{
 				objs: fs1,
 			},
+			adapterType:     mv1.AdapterType_ADAPTER_TYPE_UNSPECIFIED,
 			downloadedFiles: fs1,
 		},
 		{
@@ -70,6 +73,7 @@ func TestDownloadModelFiles(t *testing.T) {
 				},
 				objs: fs2,
 			},
+			adapterType:     mv1.AdapterType_ADAPTER_TYPE_UNSPECIFIED,
 			downloadedFiles: fs2,
 		},
 		{
@@ -77,6 +81,7 @@ func TestDownloadModelFiles(t *testing.T) {
 			s3Client: &fakeS3Client{
 				objs: fs3,
 			},
+			adapterType:     mv1.AdapterType_ADAPTER_TYPE_LORA,
 			downloadedFiles: fs3,
 		},
 	}
@@ -90,7 +95,7 @@ func TestDownloadModelFiles(t *testing.T) {
 				_ = os.RemoveAll(dir)
 			}()
 
-			err = DownloadModelFiles(context.Background(), tc.s3Client, "/src", dir)
+			err = DownloadModelFiles(context.Background(), tc.s3Client, tc.adapterType, "/src", dir)
 			assert.NoError(t, err)
 			assert.ElementsMatch(t, tc.s3Client.downloadedFiles, tc.downloadedFiles)
 		})

--- a/engine/internal/modeldownloader/modeldownloader.go
+++ b/engine/internal/modeldownloader/modeldownloader.go
@@ -39,16 +39,17 @@ func (d *D) Download(
 	modelID string,
 	srcPath string,
 	format mv1.ModelFormat,
+	adapterType mv1.AdapterType,
 ) error {
 	destPath, err := ModelFilePath(d.modelDir, modelID, format)
 	if err != nil {
 		return err
 	}
-	return d.download(ctx, modelID, format, srcPath, destPath)
+	return d.download(ctx, modelID, format, adapterType, srcPath, destPath)
 }
 
-// DownloadAdapter downloads the adapter.
-func (d *D) DownloadAdapter(
+// DownloadAdapterOfGGUF downloads the adapter.
+func (d *D) DownloadAdapterOfGGUF(
 	ctx context.Context,
 	modelID string,
 	resp *mv1.GetModelPathResponse,
@@ -57,13 +58,16 @@ func (d *D) DownloadAdapter(
 	if err != nil {
 		return err
 	}
-	return d.download(ctx, modelID, mv1.ModelFormat_MODEL_FORMAT_GGUF, resp.Path, destPath)
+
+	// TODO(kenji): Revisit the adapater type. Currently this is no-op as we don't use the HuggingFace downloader.
+	return d.download(ctx, modelID, mv1.ModelFormat_MODEL_FORMAT_GGUF, mv1.AdapterType_ADAPTER_TYPE_QLORA, resp.Path, destPath)
 }
 
 func (d *D) download(
 	ctx context.Context,
 	modelID string,
 	format mv1.ModelFormat,
+	adapter mv1.AdapterType,
 	srcPath string,
 	destPath string,
 ) error {
@@ -98,7 +102,7 @@ func (d *D) download(
 		if err := os.MkdirAll(destPath, 0755); err != nil {
 			return fmt.Errorf("create directory: %s", err)
 		}
-		if err := huggingface.DownloadModelFiles(ctx, d.s3Client, srcPath, destPath); err != nil {
+		if err := huggingface.DownloadModelFiles(ctx, d.s3Client, adapter, srcPath, destPath); err != nil {
 			return fmt.Errorf("download: %s", err)
 		}
 		log.Printf("Downloaded the model to %q\n", destPath)

--- a/engine/internal/modeldownloader/modeldownloader_test.go
+++ b/engine/internal/modeldownloader/modeldownloader_test.go
@@ -22,12 +22,12 @@ func TestDownload(t *testing.T) {
 	ctx := context.Background()
 	s3Client := &fakeS3Client{}
 	d := New(modelDir, s3Client)
-	err = d.Download(ctx, "model0", "", mv1.ModelFormat_MODEL_FORMAT_GGUF)
+	err = d.Download(ctx, "model0", "", mv1.ModelFormat_MODEL_FORMAT_GGUF, mv1.AdapterType_ADAPTER_TYPE_UNSPECIFIED)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, s3Client.numDownload)
 
 	// Run again.
-	err = d.Download(ctx, "model0", "", mv1.ModelFormat_MODEL_FORMAT_GGUF)
+	err = d.Download(ctx, "model0", "", mv1.ModelFormat_MODEL_FORMAT_GGUF, mv1.AdapterType_ADAPTER_TYPE_UNSPECIFIED)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, s3Client.numDownload)
 }


### PR DESCRIPTION
… type as argument

Some of the existing setup doesn't have the ListBucket permission. Removing the list call from the default path is required to avoid regression.

Also it would be better if we can explictily check if all necessary files exist or not depending on whether a requested model is adapter or not.