### PR TITLE
Add triton-proxy

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -73,7 +73,16 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: |
           public.ecr.aws/cloudnatix/llmariner/inference-manager-server:${{ needs.update-tag.outputs.new_version }}
-          public.ecr.aws/cloudnatix/llmariner/inference-manager-server:latest
+          public.ecr.aws/cloudnatix/llmariner/inference-manager-triton-proxy:latest
+    - name: Build, tag, and push triton-proxy to Amazon ECR
+      uses: docker/build-push-action@v5
+      with:
+        file: ./build/triton-proxy/Dockerfile
+        push: true
+        platforms: linux/amd64,linux/arm64
+        tags: |
+          public.ecr.aws/cloudnatix/llmariner/inference-manager-triton-proxy:${{ needs.update-tag.outputs.new_version }}
+          public.ecr.aws/cloudnatix/llmariner/inference-manager-triton-proxy:latest
 
   publish-helm-chart:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -73,7 +73,7 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: |
           public.ecr.aws/cloudnatix/llmariner/inference-manager-server:${{ needs.update-tag.outputs.new_version }}
-          public.ecr.aws/cloudnatix/llmariner/inference-manager-triton-proxy:latest
+          public.ecr.aws/cloudnatix/llmariner/inference-manager-server:latest
     - name: Build, tag, and push triton-proxy to Amazon ECR
       uses: docker/build-push-action@v5
       with:

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ build-server:
 build-engine:
 	go build -o ./bin/engine ./engine/cmd/
 
+.PHONY: build-triton-proxy
+build-triton-proxy:
+	go build -o ./bin/triton-proxy ./triton-proxy/cmd/
+
 .PHONY: build-docker-server
 build-docker-server:
 	docker build --build-arg TARGETARCH=amd64 -t llmariner/inference-manager-server:latest -f build/server/Dockerfile .
@@ -27,3 +31,7 @@ build-docker-server:
 .PHONY: build-docker-engine
 build-docker-engine:
 	docker build --build-arg TARGETARCH=amd64 -t llmariner/inference-manager-engine:latest -f build/engine/Dockerfile .
+
+.PHONY: build-docker-triton-proxy
+build-docker-triton-proxy:
+	docker build --build-arg TARGETARCH=amd64 -t llmariner/inference-manager-triton-proxy:latest -f build/triton-proxy/Dockerfile .

--- a/build/triton-proxy/Dockerfile
+++ b/build/triton-proxy/Dockerfile
@@ -1,0 +1,24 @@
+FROM --platform=$BUILDPLATFORM golang:1.23 AS builder
+ARG TARGETARCH
+
+WORKDIR /workspace
+COPY . .
+
+ENV GOCACHE=/root/gocache
+RUN \
+    --mount=type=cache,target=${GOCACHE} \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+RUN --mount=type=cache,target=${GOCACHE} \
+    --mount=type=cache,id=inference-manager,sharing=locked,target=/go/pkg/mod \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on make build-triton-proxy
+
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
+
+WORKDIR /run
+
+COPY --from=builder /workspace/bin/triton-proxy .
+
+ENTRYPOINT ["./triton-proxy"]

--- a/build/triton-proxy/Dockerfile
+++ b/build/triton-proxy/Dockerfile
@@ -15,7 +15,6 @@ RUN --mount=type=cache,target=${GOCACHE} \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on make build-triton-proxy
 
 FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
-ARG TARGETARCH
 
 WORKDIR /run
 

--- a/triton-proxy/cmd/main.go
+++ b/triton-proxy/cmd/main.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"log"
+	"os"
+)
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lmicroseconds | log.Lshortfile)
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/triton-proxy/cmd/root.go
+++ b/triton-proxy/cmd/root.go
@@ -1,0 +1,14 @@
+package main
+
+import "github.com/spf13/cobra"
+
+// rootCmd is the root of the command-line application.
+var rootCmd = &cobra.Command{
+	Use:   "triton-proxy",
+	Short: "triton-proxy",
+}
+
+func init() {
+	rootCmd.AddCommand(runCmd())
+	rootCmd.SilenceUsage = true
+}

--- a/triton-proxy/cmd/run.go
+++ b/triton-proxy/cmd/run.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/go-logr/stdr"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/llmariner/inference-manager/triton-proxy/internal/config"
+	"github.com/llmariner/inference-manager/triton-proxy/internal/server"
+	"github.com/llmariner/rbac-manager/pkg/auth"
+	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func runCmd() *cobra.Command {
+	var path string
+	var logLevel int
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			c, err := config.Parse(path)
+			if err != nil {
+				return err
+			}
+			if err := c.Validate(); err != nil {
+				return err
+			}
+
+			if err := run(cmd.Context(), &c, logLevel); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&path, "config", "", "Path to the config file")
+	cmd.Flags().IntVar(&logLevel, "v", 0, "Log level")
+	_ = cmd.MarkFlagRequired("config")
+	return cmd
+}
+
+func run(ctx context.Context, c *config.Config, lv int) error {
+	stdr.SetVerbosity(lv)
+	logger := stdr.New(log.Default())
+
+	mux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(runtime.MIMEWildcard, &runtime.JSONPb{
+			// Do not use the camel case for JSON fields to follow OpenAI API.
+			MarshalOptions: protojson.MarshalOptions{
+				UseProtoNames:     true,
+				EmitDefaultValues: true,
+			},
+			UnmarshalOptions: protojson.UnmarshalOptions{
+				DiscardUnknown: true,
+			},
+		}),
+		runtime.WithIncomingHeaderMatcher(auth.HeaderMatcher),
+	)
+	srv := server.New(c.TritonServerBaseURL, logger)
+
+	pat := runtime.MustPattern(
+		runtime.NewPattern(
+			1,
+			[]int{2, 0, 2, 1, 2, 2},
+			[]string{"v1", "chat", "completions"},
+			"",
+		))
+	mux.Handle("POST", pat, srv.CreateChatCompletion)
+
+	log := logger.WithName("http")
+	log.Info("Starting HTTP server...", "port", c.HTTPPort)
+	err := http.ListenAndServe(fmt.Sprintf(":%d", c.HTTPPort), mux)
+	log.Info("Stopped HTTP server")
+
+	return err
+}

--- a/triton-proxy/internal/config/config.go
+++ b/triton-proxy/internal/config/config.go
@@ -1,0 +1,42 @@
+package config
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config is the configuration.
+type Config struct {
+	HTTPPort int `yaml:"httpPort"`
+
+	TritonServerBaseURL string `yaml:"tritonServerBaseUrl"`
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	if c.HTTPPort <= 0 {
+		return fmt.Errorf("httpPort must be greater than 0")
+	}
+	if c.TritonServerBaseURL == "" {
+		return fmt.Errorf("tritonServerBaseUrl must be set")
+	}
+	return nil
+}
+
+// Parse parses the configuration file at the given path, returning a new
+// Config struct.
+func Parse(path string) (Config, error) {
+	var config Config
+
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return config, fmt.Errorf("config: read: %s", err)
+	}
+
+	if err = yaml.Unmarshal(b, &config); err != nil {
+		return config, fmt.Errorf("config: unmarshal: %s", err)
+	}
+	return config, nil
+}

--- a/triton-proxy/internal/server/completions.go
+++ b/triton-proxy/internal/server/completions.go
@@ -1,0 +1,106 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	v1 "github.com/llmariner/inference-manager/api/v1"
+)
+
+// CreateChatCompletion creates a chat completion.
+func (s *S) CreateChatCompletion(
+	w http.ResponseWriter,
+	req *http.Request,
+	pathParams map[string]string,
+) {
+	var createReq v1.CreateChatCompletionRequest
+
+	reqBody, err := io.ReadAll(req.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// TODO(kenji): Use runtime.JSONPb from github.com/grpc-ecosystem/grpc-gateway/v2.
+	// That one correctly handles the JSON field names of the snake case.
+	if err := json.Unmarshal(reqBody, &createReq); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if createReq.Model == "" {
+		http.Error(w, "Model is required", http.StatusBadRequest)
+		return
+	}
+
+	s.logger.Info("Forwarding the request to Triton Inference Server", "model", createReq.Model)
+
+	genReq := buildEnsembleGenerateRequest(&createReq)
+	b, err := json.Marshal(genReq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	path := s.tritonBaseURL + "/v2/models/ensemble/generate"
+	hreq, err := http.NewRequest(http.MethodPost, path, bytes.NewReader(b))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	hreq.Header.Add("Content-Type", "application/json")
+	hreq.Header.Add("Accept", "application/json")
+
+	hresp, err := http.DefaultClient.Do(hreq)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	defer func() { _ = hresp.Body.Close() }()
+
+	if hresp.StatusCode < http.StatusOK || hresp.StatusCode >= http.StatusBadRequest {
+		body, err := io.ReadAll(hresp.Body)
+		if err != nil {
+			// Gracefully handle the error.
+			s.logger.Error(err, "Failed to read the body")
+		}
+		s.logger.Info("Received an error response", "code", hresp.StatusCode, "status", hresp.Status, "body", string(body))
+		http.Error(w, string(body), hresp.StatusCode)
+		return
+	}
+
+	// Copy headers.
+	for k, v := range hresp.Header {
+		for _, vv := range v {
+			w.Header().Add(k, vv)
+		}
+	}
+	w.WriteHeader(hresp.StatusCode)
+
+	respBody, err := io.ReadAll(hresp.Body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var genResp ensembleGenerateResponse
+	if err := json.Unmarshal(respBody, &genResp); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	chanResp := buildChatCompletionResponse(&genResp, createReq.Model)
+	b, err = json.Marshal(chanResp)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if _, err := io.Copy(w, bytes.NewBuffer(b)); err != nil {
+		http.Error(w, fmt.Sprintf("Server error: %s", err), http.StatusInternalServerError)
+		return
+	}
+}

--- a/triton-proxy/internal/server/server.go
+++ b/triton-proxy/internal/server/server.go
@@ -8,7 +8,7 @@ import (
 func New(tritonBaseURL string, logger logr.Logger) *S {
 	return &S{
 		tritonBaseURL: tritonBaseURL,
-		logger:        logger.WithName("grpc"),
+		logger:        logger.WithName("server"),
 	}
 }
 

--- a/triton-proxy/internal/server/server.go
+++ b/triton-proxy/internal/server/server.go
@@ -1,0 +1,20 @@
+package server
+
+import (
+	"github.com/go-logr/logr"
+)
+
+// New creates a server.
+func New(tritonBaseURL string, logger logr.Logger) *S {
+	return &S{
+		tritonBaseURL: tritonBaseURL,
+		logger:        logger.WithName("grpc"),
+	}
+}
+
+// S is a server.
+type S struct {
+	tritonBaseURL string
+
+	logger logr.Logger
+}

--- a/triton-proxy/internal/server/triton.go
+++ b/triton-proxy/internal/server/triton.go
@@ -1,0 +1,45 @@
+package server
+
+import (
+	"fmt"
+
+	v1 "github.com/llmariner/inference-manager/api/v1"
+)
+
+type ensembleGenerateRequest struct {
+	TextInput string `json:"text_input"`
+	MaxTokens int    `json:"max_tokens"`
+	BadWords  string `json:"bad_words"`
+	StopWords string `json:"stop_words"`
+}
+
+func buildEnsembleGenerateRequest(req *v1.CreateChatCompletionRequest) *ensembleGenerateRequest {
+	// TODO(kenji): Revisit. This only works for Llama3.1. We should also fill other fields.
+	// this to a template.
+	input := "<|begin_of_text|>"
+	for _, m := range req.Messages {
+		input += fmt.Sprintf("<|start_header_id|> %s <|end_header_id|>\n %s '\n<|eot_id|>\n", m.Role, m.Content)
+	}
+	return &ensembleGenerateRequest{
+		TextInput: input,
+	}
+}
+
+type ensembleGenerateResponse struct {
+	TextOutput string `json:"text_output"`
+}
+
+func buildChatCompletionResponse(resp *ensembleGenerateResponse, modelID string) *v1.ChatCompletion {
+	return &v1.ChatCompletion{
+		Choices: []*v1.ChatCompletion_Choice{
+			{
+				Message: &v1.ChatCompletion_Choice_Message{
+					Content: resp.TextOutput,
+				},
+			},
+		},
+		Model:  modelID,
+		Object: "chat.completion",
+		// TODO(kenji): Fill other fields.
+	}
+}

--- a/triton-proxy/internal/server/triton_test.go
+++ b/triton-proxy/internal/server/triton_test.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"testing"
+
+	v1 "github.com/llmariner/inference-manager/api/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildEnsembleGenerateRequest(t *testing.T) {
+	req := &v1.CreateChatCompletionRequest{
+		Messages: []*v1.CreateChatCompletionRequest_Message{
+			{
+				Content: "hello",
+				Role:    "user",
+			},
+			{
+				Content: "world",
+				Role:    "system",
+			},
+		},
+	}
+	got := buildEnsembleGenerateRequest(req)
+	want := "<|begin_of_text|><|start_header_id|> user <|end_header_id|>\n hello '\n<|eot_id|>\n<|start_header_id|> system <|end_header_id|>\n world '\n<|eot_id|>\n"
+	assert.Equal(t, want, got.TextInput)
+}


### PR DESCRIPTION
This is a simple HTTP server that receives OpenAI-compatible API requests and forwards to Triton Inference Server.

We don't need this once Triton Inference Server supports OpenAI compatible API, but meanwhile we can run this together with the Triton Inference Server container in the same pod.