### PR TITLE
Do not skip a hidden file when downloading model files

### DIFF
--- a/engine/internal/modeldownloader/common/common.go
+++ b/engine/internal/modeldownloader/common/common.go
@@ -60,14 +60,9 @@ func isAccessDenied(err error) bool {
 
 func downloadAllModelFiles(ctx context.Context, s3Client s3Client, keys []string, srcS3Path, destDir string) error {
 	for _, key := range keys {
-		destPath := filepath.Join(destDir, strings.TrimPrefix(key, srcS3Path))
-
-		if strings.HasPrefix(filepath.Base(destPath), ".") {
-			log.Printf("Skip downloading hidden file: %q", key)
-			continue
-		}
-
 		log.Printf("Downloading %q to %q\n", key, destDir)
+
+		destPath := filepath.Join(destDir, strings.TrimPrefix(key, srcS3Path))
 
 		if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
 			return fmt.Errorf("create directory: %s", err)

--- a/engine/internal/modeldownloader/common/common_test.go
+++ b/engine/internal/modeldownloader/common/common_test.go
@@ -54,7 +54,6 @@ func (c *fakeS3Client) ListObjectsPages(
 		Contents: []types.Object{
 			{Key: aws.String("v1/base-models/meta-llama/Meta-Llama-3.1-70B-Instruct-awq-triton/test.txt")},
 			{Key: aws.String("v1/base-models/meta-llama/Meta-Llama-3.1-70B-Instruct-awq-triton/repo/llama3/tensorrt_llm/1/rank0.engine")},
-			{Key: aws.String("v1/base-models/meta-llama/Meta-Llama-3.1-70B-Instruct-awq-triton/.hidden")},
 		},
 	}
 	_ = f(page, true)


### PR DESCRIPTION
Triton model files contain "repo/llama3/ensemble/1/.tmp", which we cannot exclude. It seems the content of .tmp does not matter, but we need the directory.