### PR TITLE
feat(runtime): Be able to specify extra flags for vLLM

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -61,6 +61,7 @@ data:
         replicas: {{ .Values.model.default.replicas }}
         preloaded: {{ .Values.model.default.preloaded }}
         contextLength: {{ .Values.model.default.contextLength }}
+        vllmExtraFlags: {{ .Values.model.default.vllmExtraFlags }}
       overrides:
         {{- toYaml .Values.model.overrides | nindent 8 }}
     llmEngine: {{ .Values.llmEngine }}

--- a/deployments/engine/values.yaml
+++ b/deployments/engine/values.yaml
@@ -80,6 +80,7 @@ model:
     replicas: 1
     preloaded: false
     contextLength: 0
+    vllmExtraFlags:
 
   overrides:
     # sample-model:

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -203,6 +203,9 @@ type ModelConfigItem struct {
 	// ContextLength is the context length for the model. If the value is 0,
 	// the default context length is used.
 	ContextLength int `yaml:"contextLength"`
+
+	// VLLMExtraFlags is the extra flags for VLLM.
+	VLLMExtraFlags []string `yaml:"vllmExtraFlags"`
 }
 
 func (c *ModelConfigItem) validate() error {

--- a/engine/internal/config/model_config.go
+++ b/engine/internal/config/model_config.go
@@ -75,6 +75,9 @@ func (c *ProcessedModelConfig) ModelConfigItem(modelID string) ModelConfigItem {
 		if l := override.ContextLength; l > 0 {
 			item.ContextLength = l
 		}
+		if fs := override.VLLMExtraFlags; len(fs) > 0 {
+			item.VLLMExtraFlags = fs
+		}
 	}
 
 	// For backward compatibility, look at legacy fields.

--- a/engine/internal/runtime/vllm_client.go
+++ b/engine/internal/runtime/vllm_client.go
@@ -153,6 +153,10 @@ func (v *vllmClient) deployRuntimeParams(ctx context.Context, modelID string) (d
 		args = append(args, "--quantization", "awq")
 	}
 
+	if fs := mci.VLLMExtraFlags; len(fs) > 0 {
+		args = append(args, fs...)
+	}
+
 	envs := []*corev1apply.EnvVarApplyConfiguration{
 		corev1apply.EnvVar().WithName("VLLM_ALLOW_RUNTIME_LORA_UPDATING").WithValue("true"),
 		corev1apply.EnvVar().WithName("VLLM_LOGGING_LEVEL").WithValue("DEBUG"),


### PR DESCRIPTION
For some cases, we would like to set flags like --gpu-utilization or --enforce-eager.