### PR TITLE
fix(runtime): set --load-format to "bitsandbytes" for a bnb-quantized models

### DIFF
--- a/engine/internal/runtime/vllm_client.go
+++ b/engine/internal/runtime/vllm_client.go
@@ -151,6 +151,10 @@ func (v *vllmClient) deployRuntimeParams(ctx context.Context, modelID string) (d
 
 	if q, ok := vllmQuantization(modelID); ok {
 		args = append(args, "--quantization", q)
+		if q == "bitsandbytes" {
+			// BitsAndBytes quantization only supports 'bitsandbytes' load format.
+			args = append(args, "--load-format", "bitsandbytes")
+		}
 	}
 
 	envs := []*corev1apply.EnvVarApplyConfiguration{


### PR DESCRIPTION


vLLM currently supports only the 'bitsandbytes' load format for BitsAndBytes quantization.