### PR TITLE
fix(server): re-enable the engine readiness check

### DIFF
--- a/deployments/server/templates/configmap.yaml
+++ b/deployments/server/templates/configmap.yaml
@@ -24,3 +24,4 @@ data:
       rbacInternalServerAddr: {{ .Values.global.auth.rbacInternalServerAddr }}
     usageSender:
       {{- toYaml .Values.global.usageSender | nindent 6 }}
+    enableEngineReadinessCheck: {{ .Values.enableEngineReadinessCheck }}

--- a/deployments/server/values.yaml
+++ b/deployments/server/values.yaml
@@ -47,6 +47,8 @@ modelManagerServerAddr: model-manager-server-grpc:8081
 vectorStoreManagerServerAddr: vector-store-manager-server-grpc:8081
 vectorStoreManagerInternalServerAddr: vector-store-manager-server-internal-grpc:8083
 
+enableEngineReadinessCheck: true
+
 replicaCount: 1
 image:
   repository: public.ecr.aws/cloudnatix/llmariner/inference-manager-server

--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -114,7 +114,7 @@ func run(ctx context.Context, c *config.Config, lv int) error {
 	}
 
 	r := router.New()
-	infProcessor := infprocessor.NewP(r, logger)
+	infProcessor := infprocessor.NewP(r, c.EnableEngineReadinessCheck, logger)
 	go func() {
 		errCh <- infProcessor.Run(ctx)
 	}()

--- a/server/internal/config/config.go
+++ b/server/internal/config/config.go
@@ -27,6 +27,11 @@ type Config struct {
 	UsageSender sender.Config `yaml:"usageSender"`
 
 	Debug DebugConfig `yaml:"debug"`
+
+	// EnableEngineReadinessCheck enables the engine readiness check. This is set to false
+	// when the server still connects to an old version of engines that don't set the 'ready'
+	// field in the status.
+	EnableEngineReadinessCheck bool `yaml:"enableEngineReadinessCheck"`
 }
 
 // AuthConfig is the authentication configuration.

--- a/server/internal/infprocessor/infprocessor.go
+++ b/server/internal/infprocessor/infprocessor.go
@@ -111,7 +111,7 @@ type engineRouter interface {
 }
 
 // NewP creates a new processor.
-func NewP(engineRouter engineRouter, logger logr.Logger) *P {
+func NewP(engineRouter engineRouter, isEngineReadinessCheckEnabled bool, logger logr.Logger) *P {
 	return &P{
 		queue:               newTaskQueue(),
 		engineRouter:        engineRouter,
@@ -120,6 +120,8 @@ func NewP(engineRouter engineRouter, logger logr.Logger) *P {
 		logger:              logger.WithName("processor"),
 		taskTimeout:         30 * time.Second,
 		retryDelay:          3 * time.Second,
+
+		isEngineReadinessCheckEnabled: isEngineReadinessCheckEnabled,
 	}
 }
 
@@ -150,6 +152,8 @@ type P struct {
 
 	taskTimeout time.Duration
 	retryDelay  time.Duration
+
+	isEngineReadinessCheckEnabled bool
 }
 
 // Run runs the processor.
@@ -360,15 +364,14 @@ func (p *P) AddOrUpdateEngineStatus(
 	}
 	log.V(5).Info("Updated engine status", "models", e.modelIDs, "in-progress", e.inProgressModelIDs, "ready", engineStatus.Ready)
 
-	/*
-		   // TODO(kenji): Add this back once the engine is updated.
+	if p.isEngineReadinessCheckEnabled {
 		if engineStatus.Ready {
 			p.engineRouter.AddOrUpdateEngine(engineStatus.EngineId, clusterInfo.TenantID, engineStatus.ModelIds)
 		} else {
 			p.engineRouter.DeleteEngine(engineStatus.EngineId, clusterInfo.TenantID)
 			log.Info("Removed engine from the router", "reason", "engine not ready")
 		}
-	*/
+	}
 	p.engineRouter.AddOrUpdateEngine(engineStatus.EngineId, clusterInfo.TenantID, engineStatus.ModelIds)
 }
 

--- a/server/internal/infprocessor/infprocessor_test.go
+++ b/server/internal/infprocessor/infprocessor_test.go
@@ -20,6 +20,7 @@ func TestP(t *testing.T) {
 
 	iprocessor := NewP(
 		&fakeEngineRouter{},
+		true,
 		testutil.NewTestLogger(t),
 	)
 	iprocessor.taskTimeout = 0
@@ -75,6 +76,7 @@ func TestEmbedding(t *testing.T) {
 
 	iprocessor := NewP(
 		&fakeEngineRouter{},
+		true,
 		testutil.NewTestLogger(t),
 	)
 	iprocessor.taskTimeout = 0
@@ -125,6 +127,7 @@ func TestRemoveEngineWithInProgressTask(t *testing.T) {
 
 	iprocessor := NewP(
 		&fakeEngineRouter{},
+		true,
 		testutil.NewTestLogger(t),
 	)
 	iprocessor.taskTimeout = 0
@@ -171,6 +174,7 @@ func TestProcessTaskResultAfterContextCancel(t *testing.T) {
 
 	iprocessor := NewP(
 		&fakeEngineRouter{},
+		true,
 		testutil.NewTestLogger(t),
 	)
 	iprocessor.taskTimeout = 0
@@ -215,6 +219,7 @@ func TestProcessTaskResultAfterContextCancel(t *testing.T) {
 func TestFindLeastLoadedEngine(t *testing.T) {
 	p := NewP(
 		&fakeEngineRouter{},
+		true,
 		testutil.NewTestLogger(t),
 	)
 


### PR DESCRIPTION
We temporarily disabled this since there is an old version of inference-manager-engine that doesn't set the 'ready' field.

Add back the code, but also add a flag to disable this.