### PR TITLE
feat(server): use engine status in DB to route requests

### DIFF
--- a/server/cmd/run.go
+++ b/server/cmd/run.go
@@ -17,7 +17,6 @@ import (
 	"github.com/llmariner/inference-manager/server/internal/infprocessor"
 	"github.com/llmariner/inference-manager/server/internal/monitoring"
 	"github.com/llmariner/inference-manager/server/internal/rag"
-	"github.com/llmariner/inference-manager/server/internal/router"
 	"github.com/llmariner/inference-manager/server/internal/server"
 	"github.com/llmariner/inference-manager/server/internal/store"
 	mv1 "github.com/llmariner/model-manager/api/v1"
@@ -136,8 +135,7 @@ func run(ctx context.Context, c *config.Config, lv int) error {
 		rwt = rag.NewR(c.AuthConfig.Enable, vsInternalClient, logger)
 	}
 
-	r := router.New()
-	infProcessor := infprocessor.NewP(r, engineTracker, c.EnableEngineReadinessCheck, logger)
+	infProcessor := infprocessor.NewP(engineTracker, c.EnableEngineReadinessCheck, logger)
 	go func() {
 		errCh <- infProcessor.Run(ctx)
 	}()

--- a/server/internal/infprocessor/engine_tracker.go
+++ b/server/internal/infprocessor/engine_tracker.go
@@ -2,6 +2,7 @@ package infprocessor
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/llmariner/inference-manager/server/internal/store"
@@ -10,13 +11,35 @@ import (
 	v1 "github.com/llmariner/inference-manager/api/v1"
 )
 
+const (
+	// cacheStalePeriod is the duration after which the cache is considered stale.
+	cacheStalePeriod = 30 * time.Second
+
+	// engineActivePeriod is the duration after which the engine is considered inactive if there is no status update.
+	engineActivePeriod = 1 * time.Minute
+)
+
 // NewEngineTracker creates a new EngineTracker.
 func NewEngineTracker(store *store.S, localPodName, localPodIP string) *EngineTracker {
 	return &EngineTracker{
 		store:        store,
 		localPodName: localPodName,
 		localPodIP:   localPodIP,
+
+		tenantStatuses: make(map[string]*tenantStatus),
 	}
+}
+
+type tenantStatus struct {
+	// enginesByModelID is a map from model ID to a slice of engines. It is used to cache DB query results.
+	enginesByModelID map[string][]*store.Engine
+
+	// allEngines is a slice of all engines for the tenant.
+	allEngines []*store.Engine
+
+	lastUpdatedAt time.Time
+
+	mu sync.Mutex
 }
 
 // EngineTracker trackes the status of the engines across multiple server pods.
@@ -25,6 +48,11 @@ type EngineTracker struct {
 
 	localPodName string
 	localPodIP   string
+
+	// tenantStatuses is a map from tenant IDs to cached tenantStatuses.
+	tenantStatuses map[string]*tenantStatus
+	// mu protects tenantStatuses.
+	mu sync.Mutex
 }
 
 func (t *EngineTracker) addOrUpdateEngine(status *v1.EngineStatus, tenantID string) error {
@@ -45,12 +73,105 @@ func (t *EngineTracker) addOrUpdateEngine(status *v1.EngineStatus, tenantID stri
 	if err := t.store.CreateOrUpdateEngine(e); err != nil {
 		return fmt.Errorf("add or update engine: %s", err)
 	}
+
+	t.invalidateTenantStatus(tenantID)
+
 	return nil
 }
 
-func (t *EngineTracker) deleteEngine(engineID string) error {
+func (t *EngineTracker) deleteEngine(engineID, tenantID string) error {
 	if err := t.store.DeleteEngine(engineID); err != nil {
 		return fmt.Errorf("delete engine: %s", err)
 	}
+
+	t.invalidateTenantStatus(tenantID)
+
 	return nil
+}
+
+// getEngineIDsForModel returns a list of engine IDs for the given model ID and tenant ID.
+func (t *EngineTracker) getEngineIDsForModel(modelID, tenantID string) ([]string, error) {
+	ts, err := t.getTenantStatus(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("get tenant status: %s", err)
+	}
+
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	engines := ts.enginesByModelID[modelID]
+	if len(engines) == 0 {
+		// No engine is available for the model. Just return all engines.
+		engines = ts.allEngines
+		// Return an error if no engine is available.
+		if len(engines) == 0 {
+			return nil, fmt.Errorf("no engine is available")
+		}
+	}
+
+	var ids []string
+	for _, e := range engines {
+		ids = append(ids, e.EngineID)
+	}
+	return ids, nil
+}
+
+func (t *EngineTracker) getTenantStatus(tenantID string) (*tenantStatus, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	// Return the cached tenant status if it is not stale.
+	ts, ok := t.tenantStatuses[tenantID]
+	if ok && time.Since(ts.lastUpdatedAt) < cacheStalePeriod {
+		return ts, nil
+	}
+
+	// Reconstrct the tenant status.
+
+	engines, err := t.store.ListEnginesByTenantID(tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list engines by tenant ID: %s", err)
+	}
+	ts, err = buildTenantStatus(engines, time.Now())
+	if err != nil {
+		return nil, fmt.Errorf("build tenant status: %s", err)
+	}
+	t.tenantStatuses[tenantID] = ts
+	return ts, nil
+}
+
+func (t *EngineTracker) invalidateTenantStatus(tenantID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	delete(t.tenantStatuses, tenantID)
+}
+
+func buildTenantStatus(engines []*store.Engine, now time.Time) (*tenantStatus, error) {
+	ts := &tenantStatus{
+		enginesByModelID: map[string][]*store.Engine{},
+		lastUpdatedAt:    now,
+	}
+
+	for _, e := range engines {
+		if !e.IsReady {
+			continue
+		}
+
+		if e.LastStatusUpdatedAt < now.Add(-engineActivePeriod).UnixNano() {
+			// Skip inactive engines.
+			continue
+		}
+
+		ts.allEngines = append(ts.allEngines, e)
+
+		status := &v1.EngineStatus{}
+		if err := proto.Unmarshal(e.Status, status); err != nil {
+			return nil, fmt.Errorf("unmarshal engine status: %s", err)
+		}
+		for _, modelID := range status.ModelIds {
+			ts.enginesByModelID[modelID] = append(ts.enginesByModelID[modelID], e)
+		}
+	}
+
+	return ts, nil
 }

--- a/server/internal/infprocessor/engine_tracker_test.go
+++ b/server/internal/infprocessor/engine_tracker_test.go
@@ -1,9 +1,12 @@
 package infprocessor
 
 import (
+	"reflect"
 	"testing"
+	"time"
 
 	"github.com/llmariner/inference-manager/server/internal/store"
+	"google.golang.org/protobuf/proto"
 
 	v1 "github.com/llmariner/inference-manager/api/v1"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +31,18 @@ func TestEngineTracker(t *testing.T) {
 	assert.Equal(t, "e0", got[0].EngineID)
 	assert.True(t, got[0].IsReady)
 
+	gotIDs, err := et.getEngineIDsForModel("m0", "tenant0")
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(gotIDs))
+	assert.Equal(t, "e0", gotIDs[0])
+
+	gotIDs, err = et.getEngineIDsForModel("other model", "tenant0")
+	assert.NoError(t, err)
+	assert.Equal(t, "e0", gotIDs[0])
+
+	_, err = et.getEngineIDsForModel("m0", "other tenant")
+	assert.Error(t, err)
+
 	// Update the status.
 	es.Ready = false
 	err = et.addOrUpdateEngine(es, "tenant0")
@@ -40,10 +55,147 @@ func TestEngineTracker(t *testing.T) {
 	assert.False(t, got[0].IsReady)
 
 	// Delete the status.
-	err = et.deleteEngine("e0")
+	err = et.deleteEngine("e0", "tenant0")
 	assert.NoError(t, err)
 
 	got, err = st.ListEnginesByTenantID("tenant0")
 	assert.NoError(t, err)
 	assert.Empty(t, got)
+
+	_, err = et.getEngineIDsForModel("m0", "tenant0")
+	assert.Error(t, err)
+}
+
+func TestBuildTenantStatus(t *testing.T) {
+	now := time.Now()
+
+	status0 := &v1.EngineStatus{
+		EngineId: "e0",
+		ModelIds: []string{"m0", "m1"},
+	}
+	b0, err := proto.Marshal(status0)
+	assert.NoError(t, err)
+
+	status1 := &v1.EngineStatus{
+		EngineId: "e1",
+		ModelIds: []string{"m1"},
+	}
+	b1, err := proto.Marshal(status1)
+	assert.NoError(t, err)
+
+	tcs := []struct {
+		name    string
+		engines []*store.Engine
+		want    map[string][]*store.Engine
+	}{
+		{
+			name:    "no engines",
+			engines: []*store.Engine{},
+			want:    map[string][]*store.Engine{},
+		},
+		{
+			name: "ready engines",
+			engines: []*store.Engine{
+				{
+					EngineID:            "e0",
+					Status:              b0,
+					IsReady:             true,
+					LastStatusUpdatedAt: now.UnixNano(),
+				},
+				{
+					EngineID:            "e1",
+					Status:              b1,
+					IsReady:             true,
+					LastStatusUpdatedAt: now.UnixNano(),
+				},
+			},
+			want: map[string][]*store.Engine{
+				"m0": {
+					{
+						EngineID:            "e0",
+						Status:              b0,
+						IsReady:             true,
+						LastStatusUpdatedAt: now.UnixNano(),
+					},
+				},
+				"m1": {
+					{
+						EngineID:            "e0",
+						Status:              b0,
+						IsReady:             true,
+						LastStatusUpdatedAt: now.UnixNano(),
+					},
+					{
+						EngineID:            "e1",
+						Status:              b1,
+						IsReady:             true,
+						LastStatusUpdatedAt: now.UnixNano(),
+					},
+				},
+			},
+		},
+		{
+			name: "ignore unready engines",
+			engines: []*store.Engine{
+				{
+					EngineID:            "e0",
+					Status:              b0,
+					IsReady:             false,
+					LastStatusUpdatedAt: now.UnixNano(),
+				},
+				{
+					EngineID:            "e1",
+					Status:              b1,
+					IsReady:             true,
+					LastStatusUpdatedAt: now.UnixNano(),
+				},
+			},
+			want: map[string][]*store.Engine{
+				"m1": {
+					{
+						EngineID:            "e1",
+						Status:              b1,
+						IsReady:             true,
+						LastStatusUpdatedAt: now.UnixNano(),
+					},
+				},
+			},
+		},
+		{
+			name: "ignore stale engines",
+			engines: []*store.Engine{
+				{
+					EngineID:            "e0",
+					Status:              b0,
+					IsReady:             true,
+					LastStatusUpdatedAt: now.Add(-2 * engineActivePeriod).UnixNano(),
+				},
+				{
+					EngineID:            "e1",
+					Status:              b1,
+					IsReady:             true,
+					LastStatusUpdatedAt: now.UnixNano(),
+				},
+			},
+			want: map[string][]*store.Engine{
+				"m1": {
+					{
+						EngineID:            "e1",
+						Status:              b1,
+						IsReady:             true,
+						LastStatusUpdatedAt: now.UnixNano(),
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := buildTenantStatus(tc.engines, now)
+			assert.NoError(t, err)
+			assert.Truef(t, reflect.DeepEqual(tc.want, got.enginesByModelID), "want: %v, got: %v", tc.want, got.enginesByModelID)
+		})
+	}
+
 }

--- a/server/internal/server/ws_server.go
+++ b/server/internal/server/ws_server.go
@@ -169,7 +169,9 @@ func (ws *WS) processTasks(srv serverInterface) error {
 		}
 		if !registered && engineID != "" {
 			defer func() {
-				ws.infProcessor.RemoveEngine(engineID, clusterInfo)
+				if err := ws.infProcessor.RemoveEngine(engineID, clusterInfo); err != nil {
+					ws.logger.Error(err, "RemoveEngine error", "engineID", engineID)
+				}
 				ws.logger.Info("Unregistered engine", "engineID", engineID)
 			}()
 			registered = true
@@ -190,7 +192,9 @@ func (ws *WS) processMessagesFromEngine(
 	switch msg := req.Message.(type) {
 	case *v1.ProcessTasksRequest_EngineStatus:
 		ws.logger.Info("Received engine status", "engineID", msg.EngineStatus.EngineId)
-		ws.infProcessor.AddOrUpdateEngineStatus(srv, msg.EngineStatus, clusterInfo)
+		if err := ws.infProcessor.AddOrUpdateEngineStatus(srv, msg.EngineStatus, clusterInfo); err != nil {
+			return "", err
+		}
 		engineID = msg.EngineStatus.EngineId
 	case *v1.ProcessTasksRequest_TaskResult:
 		if err := ws.infProcessor.ProcessTaskResult(msg.TaskResult, clusterInfo); err != nil {


### PR DESCRIPTION
The forwarding logic has not yet been implemented, but use DB to route requests.