### PR TITLE
chore(engine): remove the 'ctx' arg from sendEngineStatus

### DIFF
--- a/engine/internal/processor/processor.go
+++ b/engine/internal/processor/processor.go
@@ -38,7 +38,7 @@ const (
 
 // ModelSyncer syncs models.
 type ModelSyncer interface {
-	ListSyncedModelIDs(ctx context.Context) []string
+	ListSyncedModelIDs() []string
 	PullModel(ctx context.Context, modelID string) error
 	ListInProgressModels() []string
 }
@@ -223,7 +223,7 @@ func (p *P) sendEngineStatusPeriodically(
 
 	isFirst := true
 	for {
-		if err := p.sendEngineStatus(ctx, stream, true); err != nil {
+		if err := p.sendEngineStatus(stream, true); err != nil {
 			return err
 		}
 
@@ -242,7 +242,7 @@ func (p *P) sendEngineStatusPeriodically(
 		case <-stream.Context().Done():
 			return nil
 		case <-ctx.Done():
-			if err := p.sendEngineStatus(ctx, stream, false); err != nil {
+			if err := p.sendEngineStatus(stream, false); err != nil {
 				return err
 			}
 			return nil
@@ -512,12 +512,12 @@ func (p *P) buildRequest(ctx context.Context, t *v1.Task) (*http.Request, error)
 	return req, nil
 }
 
-func (p *P) sendEngineStatus(ctx context.Context, stream sender, ready bool) error {
+func (p *P) sendEngineStatus(stream sender, ready bool) error {
 	req := &v1.ProcessTasksRequest{
 		Message: &v1.ProcessTasksRequest_EngineStatus{
 			EngineStatus: &v1.EngineStatus{
 				EngineId: p.engineID,
-				ModelIds: p.modelSyncer.ListSyncedModelIDs(ctx),
+				ModelIds: p.modelSyncer.ListSyncedModelIDs(),
 				SyncStatus: &v1.EngineStatus_SyncStatus{
 					InProgressModelIds: p.modelSyncer.ListInProgressModels(),
 				},

--- a/engine/internal/processor/processor_test.go
+++ b/engine/internal/processor/processor_test.go
@@ -165,7 +165,7 @@ func (s *fakeOllamaServer) port() int {
 type fakeModelSyncer struct {
 }
 
-func (f *fakeModelSyncer) ListSyncedModelIDs(ctx context.Context) []string {
+func (f *fakeModelSyncer) ListSyncedModelIDs() []string {
 	return nil
 }
 

--- a/engine/internal/runtime/manager.go
+++ b/engine/internal/runtime/manager.go
@@ -130,7 +130,7 @@ func (m *Manager) GetLLMAddress(modelID string) (string, error) {
 }
 
 // ListSyncedModelIDs returns the list of models that are synced.
-func (m *Manager) ListSyncedModelIDs(ctx context.Context) []string {
+func (m *Manager) ListSyncedModelIDs() []string {
 	return m.listModels(true)
 }
 

--- a/engine/internal/runtime/manager_test.go
+++ b/engine/internal/runtime/manager_test.go
@@ -130,7 +130,7 @@ func TestListSyncedModelIDs(t *testing.T) {
 			"model-2": newReadyRuntime("test2"),
 		},
 	}
-	models := mgr.ListSyncedModelIDs(context.Background())
+	models := mgr.ListSyncedModelIDs()
 	assert.Len(t, models, 2)
 	assert.Contains(t, models, "model-0")
 	assert.Contains(t, models, "model-2")


### PR DESCRIPTION
The 'ctx' arg is unused. This is also misleading since the function is called after the context is canceled.