### PR TITLE
fix(common): fix a race condition in NewTestLogger

### DIFF
--- a/common/pkg/test/log.go
+++ b/common/pkg/test/log.go
@@ -13,7 +13,6 @@ import (
 
 // NewTestLogger returns a logger that writes to the test log.
 func NewTestLogger(t *testing.T) logr.Logger {
-	stdr.SetVerbosity(8)
 	logger := log.New(&testLogWriter{t}, "TEST: ", 0)
 	return stdr.New(logger)
 }
@@ -31,4 +30,9 @@ type testLogWriter struct {
 func (w *testLogWriter) Write(p []byte) (n int, err error) {
 	w.t.Log(strings.TrimSpace(string(p)))
 	return len(p), nil
+}
+
+func init() {
+	// For dubugging. We set this from here to avoid race conditions.
+	stdr.SetVerbosity(8)
 }

--- a/common/pkg/test/log.go
+++ b/common/pkg/test/log.go
@@ -2,19 +2,17 @@ package test
 
 import (
 	"context"
-	"log"
 	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
-	"github.com/go-logr/stdr"
+	"github.com/go-logr/logr/testr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // NewTestLogger returns a logger that writes to the test log.
 func NewTestLogger(t *testing.T) logr.Logger {
-	logger := log.New(&testLogWriter{t}, "TEST: ", 0)
-	return stdr.New(logger)
+	return testr.NewWithOptions(t, testr.Options{Verbosity: 8})
 }
 
 // ContextWithLogger returns a context with a logger that writes to the test log.
@@ -30,9 +28,4 @@ type testLogWriter struct {
 func (w *testLogWriter) Write(p []byte) (n int, err error) {
 	w.t.Log(strings.TrimSpace(string(p)))
 	return len(p), nil
-}
-
-func init() {
-	// For dubugging. We set this from here to avoid race conditions.
-	stdr.SetVerbosity(8)
 }


### PR DESCRIPTION
Call stdr.SetVerbosity(8) from init() to avoid a test failure like below:

https://github.com/llmariner/inference-manager/actions/runs/11504696862/job/32024755965