### PR TITLE
chore(server): update Engines() to LocalEngines()

### DIFF
--- a/server/internal/infprocessor/infprocessor.go
+++ b/server/internal/infprocessor/infprocessor.go
@@ -607,8 +607,8 @@ func processTaskResult(
 	return nil
 }
 
-// Engines returns the engine statuses grouped by tenant ID.
-func (p *P) Engines() map[string][]*v1.EngineStatus {
+// LocalEngines returns the local engine statuses grouped by tenant ID.
+func (p *P) LocalEngines() map[string][]*v1.EngineStatus {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
@@ -616,6 +616,10 @@ func (p *P) Engines() map[string][]*v1.EngineStatus {
 	for tenantID, es := range p.engines {
 		var engines []*v1.EngineStatus
 		for _, e := range es {
+			if !e.isLocal {
+				continue
+			}
+
 			engines = append(engines, &v1.EngineStatus{
 				EngineId: e.id,
 				ModelIds: e.modelIDs,

--- a/server/internal/infprocessor/infprocessor_test.go
+++ b/server/internal/infprocessor/infprocessor_test.go
@@ -59,7 +59,7 @@ func TestP(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "ok", string(body))
 
-	engines := iprocessor.Engines()
+	engines := iprocessor.LocalEngines()
 	assert.Len(t, engines, 1)
 	assert.Len(t, engines["tenant0"], 1)
 
@@ -377,6 +377,30 @@ func TestFindMostPreferredtEngine_PreferLocal(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, tc.want, engine.id)
 	}
+}
+
+func TestLocalEngines(t *testing.T) {
+	p := NewP(
+		router.New(),
+		testutil.NewTestLogger(t),
+	)
+
+	p.engines = map[string]map[string]*engine{
+		"tenant0": {
+			"e0": {
+				id:      "e0",
+				isLocal: true,
+			},
+			"e1": {
+				id:      "e1",
+				isLocal: false,
+			},
+		},
+	}
+
+	got := p.LocalEngines()
+	assert.Len(t, got, 1)
+	assert.Equal(t, "e0", got["tenant0"][0].EngineId)
 }
 
 func TestDumpStatus(t *testing.T) {


### PR DESCRIPTION
We need a function that returns only local engines. Including remote engines cause a loop in a status reporting.