### PR TITLE
feat(engine): set VLLM_RPC_TIMEOUT to a larger value

### DIFF
--- a/engine/internal/runtime/vllm_client.go
+++ b/engine/internal/runtime/vllm_client.go
@@ -164,6 +164,10 @@ func (v *vllmClient) deployRuntimeParams(ctx context.Context, modelID string) (d
 	envs := []*corev1apply.EnvVarApplyConfiguration{
 		corev1apply.EnvVar().WithName("VLLM_ALLOW_RUNTIME_LORA_UPDATING").WithValue("true"),
 		corev1apply.EnvVar().WithName("VLLM_LOGGING_LEVEL").WithValue("DEBUG"),
+		// Increase the timeout (default: 10 seconds) as we hit
+		// https://github.com/vllm-project/vllm/discussions/9418 when
+		// running the Nvidia Llama3.1 Nemotron 70B with a larger context size.
+		corev1apply.EnvVar().WithName("VLLM_RPC_TIMEOUT").WithValue("60000"),
 	}
 
 	return deployRuntimeParams{


### PR DESCRIPTION
Increase the RPC timeout (default: 10 seconds) as we hit https://github.com/vllm-project/vllm/discussions/9418 when running the Nvidia Llama3.1 Nemotron 70B with a larger context size.