### PR TITLE
feat(engine): propagate pod annotations to runtime pods

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -29,6 +29,10 @@ data:
       {{- end }}
       {{- end }}
       serviceAccountName: {{ include "inference-manager-engine.serviceAccountName" . }}
+      {{- with .Values.podAnnotations }}
+      podAnnotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/engine/internal/config/config.go
+++ b/engine/internal/config/config.go
@@ -82,6 +82,8 @@ type RuntimeConfig struct {
 
 	ServiceAccountName string `yaml:"serviceAccountName"`
 
+	PodAnnotations map[string]string `yaml:"podAnnotations"`
+
 	NodeSelector         map[string]string  `yaml:"nodeSelector"`
 	Tolerations          []TolerationConfig `yaml:"tolerations"`
 	UnstructuredAffinity any                `yaml:"affinity"`


### PR DESCRIPTION
One use case is to pass an annotation for kube2iam, but this should be generally useful.