### PR TITLE
ci(chart): cleanup LLMariner Chart.lock for test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,7 @@ update-llmariner:
 .PHONY: configure-llma-chart
 configure-llma-chart:
 	hack/overwrite-llma-chart-for-test.sh $(CLONE_PATH)
+	-rm $(CLONE_PATH)/deployments/llmariner/Chart.lock
 
 .PHONY: setup-cluster
 setup-cluster: create-kind-cluster helm-apply-deps


### PR DESCRIPTION
To avoid failure in applying helmfile after updating llmariner repostiory.