### PR TITLE
fix(engine): unset legacyContent

### DIFF
--- a/engine/internal/processor/processor.go
+++ b/engine/internal/processor/processor.go
@@ -480,6 +480,11 @@ func (p *P) buildRequest(ctx context.Context, t *v1.Task) (*http.Request, error)
 		// Convert the model name as we do the same conversion when creating (fine-tuned) models in Ollama.
 		// TODO(kenji): Revisit when we supfport fine-tuning models in vLLM.
 		r.Model = ollama.ModelName(r.Model)
+		for _, msg := range r.Messages {
+			if len(msg.LegacyContent) > 0 {
+				msg.LegacyContent = ""
+			}
+		}
 		reqBody, err = json.Marshal(r)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Run into error when sending request to vllm:
` 'msg': 'Extra inputs are not permitted', 'input': 'what is k8s?'}, {'type': 'extra_forbidden', 'loc': ('body', 'messages', 0, 'typed-dict', 'legacy_content'), 
`