### PR TITLE
chore(hack): implicitly specify the dependency components for test

### DIFF
--- a/hack/helm-apply-deps.sh
+++ b/hack/helm-apply-deps.sh
@@ -7,4 +7,4 @@ LLMA_PATH=${1:?LLMariner Path}
 cd ${LLMA_PATH}/provision/dev
 helmfile apply \
          --skip-diff-on-install \
-         --selector tier!=monitoring,app!=llmariner,app!=milvus
+         -l app=kong -l app=postgres -l app=minio


### PR DESCRIPTION
fake-gpu-operator is removed from the dependency.