### PR TITLE
feat(engine): set --tensor-paralle-size for Inferentia nodes

### DIFF
--- a/engine/internal/runtime/vllm_client_test.go
+++ b/engine/internal/runtime/vllm_client_test.go
@@ -179,6 +179,14 @@ func TestNumGPUs(t *testing.T) {
 								},
 							},
 						},
+						"model2": {
+							Resources: config.Resources{
+								Limits: map[string]string{
+									awsNeuroncoreResource: "1",
+									"cpu":                 "3",
+								},
+							},
+						},
 					},
 				},
 			}),
@@ -199,6 +207,11 @@ func TestNumGPUs(t *testing.T) {
 			name:    "model1",
 			modelID: "model1",
 			want:    0,
+		},
+		{
+			name:    "model2",
+			modelID: "model2",
+			want:    1,
 		},
 	}
 


### PR DESCRIPTION
Inferentia nodes have the "aws.amazon.com/neuroncore" resource. When the resource is allocated to a vLLM pod, --tensor-paralle-size is set to the same value.