### PR TITLE
fix(server): fix a data race in TestSendAndProcessTask

### DIFF
--- a/server/internal/infprocessor/infprocessor_test.go
+++ b/server/internal/infprocessor/infprocessor_test.go
@@ -252,16 +252,21 @@ func TestSendAndProcessTask(t *testing.T) {
 	}
 
 	resultCh := make(chan *v1.TaskResult)
+	done := make(chan struct{})
 	go func() {
 		f := func(r *v1.TaskResult) error {
 			resultCh <- r
 			return nil
 		}
 		_ = iprocessor.SendAndProcessTask(ctx, task, "tenant0", f)
+		close(done)
 	}()
 
 	resp := <-resultCh
 	assert.Equal(t, http.StatusOK, int(resp.GetHttpResponse().StatusCode))
+
+	// Wait for the task completion.
+	<-done
 }
 
 func TestFindMostPreferredtEngine(t *testing.T) {


### PR DESCRIPTION
https://github.com/llmariner/inference-manager/actions/runs/12757123737/job/35557380598?pr=540

Finish the test after the gorountime completes. Otherwise the logging can cause a data race error.