### PR TITLE
chore(engine): add the position of return bool values of addRunTime

### DIFF
--- a/engine/internal/runtime/manager.go
+++ b/engine/internal/runtime/manager.go
@@ -70,7 +70,7 @@ type runtime struct {
 	waitCh chan struct{}
 }
 
-func (m *Manager) addRuntime(modelID string, sts appsv1.StatefulSet) (ready bool, added bool, err error) {
+func (m *Manager) addRuntime(modelID string, sts appsv1.StatefulSet) (added bool, ready bool, err error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if _, ok := m.runtimes[modelID]; ok {
@@ -86,7 +86,7 @@ func (m *Manager) addRuntime(modelID string, sts appsv1.StatefulSet) (ready bool
 	} else {
 		m.runtimes[modelID] = newPendingRuntime(sts.Name)
 	}
-	return ready, true, nil
+	return true, ready, nil
 }
 
 func (m *Manager) deleteRuntime(name string) {
@@ -295,7 +295,7 @@ func (m *Manager) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result,
 		// This would call when the manager synchronizes the cache
 		// for the first time or when another engine creates a runtime.
 		log.V(4).Info("Registering runtime", "model", modelID)
-		if ready, added, err := m.addRuntime(modelID, sts); err != nil {
+		if added, ready, err := m.addRuntime(modelID, sts); err != nil {
 			log.Error(err, "Failed to add runtime")
 			return ctrl.Result{}, err
 		} else if added {

--- a/engine/internal/runtime/manager_test.go
+++ b/engine/internal/runtime/manager_test.go
@@ -40,20 +40,20 @@ func TestAddRuntime(t *testing.T) {
 		runtimes:        map[string]runtime{},
 	}
 
-	ready, added, err := mgr.addRuntime("model-0", createSts("rt-0", 1))
+	added, ready, err := mgr.addRuntime("model-0", createSts("rt-0", 1))
 	assert.NoError(t, err)
+	assert.True(t, added)
 	assert.True(t, ready)
-	assert.True(t, added)
 	assert.True(t, mgr.runtimes["model-0"].ready)
-	ready, added, err = mgr.addRuntime("model-0", createSts("rt-0", 1))
+	added, ready, err = mgr.addRuntime("model-0", createSts("rt-0", 1))
 	assert.NoError(t, err)
-	assert.False(t, ready)
 	assert.False(t, added)
-
-	ready, added, err = mgr.addRuntime("model-1", createSts("rt-1", 0))
-	assert.NoError(t, err)
 	assert.False(t, ready)
+
+	added, ready, err = mgr.addRuntime("model-1", createSts("rt-1", 0))
+	assert.NoError(t, err)
 	assert.True(t, added)
+	assert.False(t, ready)
 	assert.False(t, mgr.runtimes["model-1"].ready)
 	assert.Len(t, mgr.runtimes, 2)
 }


### PR DESCRIPTION
Swap the position of 'added' and 'ready' for the following reasons:

- The caller first checks 'added'.
- 'ready' is set to a meaningful value only when 'added' is true.