### PR TITLE
fix(server): drop unneeded headers

### DIFF
--- a/server/internal/server/completions.go
+++ b/server/internal/server/completions.go
@@ -126,7 +126,7 @@ func (s *S) CreateChatCompletion(
 		return
 	}
 
-	resp, err := s.taskSender.SendChatCompletionTask(ctx, userInfo.TenantID, &createReq, req.Header)
+	resp, err := s.taskSender.SendChatCompletionTask(ctx, userInfo.TenantID, &createReq, dropUnnecessaryHeaders(req.Header))
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError, &usage)
 		return
@@ -352,4 +352,17 @@ func newUsageRecord(ui auth.UserInfo, t time.Time, method string) auv1.UsageReco
 func httpError(w http.ResponseWriter, error string, code int, usage *auv1.UsageRecord) {
 	usage.StatusCode = int32(code)
 	http.Error(w, error, code)
+}
+
+// drop unnecessary headers that we don't want to pass to engine.
+func dropUnnecessaryHeaders(headers http.Header) http.Header {
+	// TODO(kenji): Add more.
+	ks := []string{
+		"Authorization",
+		"Origin",
+	}
+	for _, k := range ks {
+		headers.Del(k)
+	}
+	return headers
 }

--- a/server/internal/server/embeddings.go
+++ b/server/internal/server/embeddings.go
@@ -82,7 +82,7 @@ func (s *S) CreateEmbedding(
 		return
 	}
 
-	resp, err := s.taskSender.SendEmbeddingTask(ctx, userInfo.TenantID, &createReq, req.Header)
+	resp, err := s.taskSender.SendEmbeddingTask(ctx, userInfo.TenantID, &createReq, dropUnnecessaryHeaders(req.Header))
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError, &usage)
 		return

--- a/server/internal/server/legacy_completions.go
+++ b/server/internal/server/legacy_completions.go
@@ -95,7 +95,7 @@ func (s *S) CreateCompletion(
 		return
 	}
 
-	resp, err := s.taskSender.SendChatCompletionTask(ctx, userInfo.TenantID, toCreateChatCompletionRequest(&createReq), req.Header)
+	resp, err := s.taskSender.SendChatCompletionTask(ctx, userInfo.TenantID, toCreateChatCompletionRequest(&createReq), dropUnnecessaryHeaders(req.Header))
 	if err != nil {
 		httpError(w, err.Error(), http.StatusInternalServerError, &usage)
 		return


### PR DESCRIPTION
Passing headers like Origin makes Ollama return 403. We can set env var OLLAMA_ORIGINS to "*" in Ollama containers (c.f., https://github.com/ollama/ollama/issues/4115) to work around 403, but it's better to drop the headers.