### PR TITLE
fix: fix the resources field in the configmap

### DIFF
--- a/deployments/engine/templates/configmap.yaml
+++ b/deployments/engine/templates/configmap.yaml
@@ -55,7 +55,20 @@ data:
       default:
         runtimeName: {{ .Values.model.default.runtimeName }}
         resources:
-          {{- toYaml .Values.model.default.resources | nindent 10 }}
+        {{- with .Values.model.default.resources }}
+          {{- with .requests }}
+          requests:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .limits }}
+          limits:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .volume }}
+          volume:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+        {{- end }}
         replicas: {{ .Values.model.default.replicas }}
         preloaded: {{ .Values.model.default.preloaded }}
         contextLength: {{ .Values.model.default.contextLength }}


### PR DESCRIPTION
With https://github.com/llmariner/inference-manager/pull/583, we get the following in the configmap:

```yaml
  model:
    default:
      runtimeName: ollama
       resources:
         volume: {}
```

Since volume is set, we get the following error:

```bash
  Error: model: default: volume: accessMode must be set
```

To make the 'volume' field optional, set the invidiual fields resources separately.