### PR TITLE
fix: set ClusterId from LocalEngines

### DIFF
--- a/server/internal/infprocessor/infprocessor.go
+++ b/server/internal/infprocessor/infprocessor.go
@@ -590,7 +590,8 @@ func (p *P) LocalEngines() map[string][]*v1.EngineStatus {
 				SyncStatus: &v1.EngineStatus_SyncStatus{
 					InProgressModelIds: e.inProgressModelIDs,
 				},
-				Ready: true,
+				Ready:     true,
+				ClusterId: e.clusterID,
 			})
 		}
 		result[tenantID] = engines


### PR DESCRIPTION
The LocalEngines function is used when an inference-manager-server instance reports its connected engines to other instances.

Setting the clusterId here is needed to properly show clusters in the status endpoint.