### PR TITLE
fix: use normal distroless image as a base image for the engine

### DIFF
--- a/build/engine/Dockerfile
+++ b/build/engine/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,id=inference-manager,sharing=locked,target=/go/pkg/mod \
     CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} GO111MODULE=on make build-engine
 
-FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:nonroot
+FROM --platform=$BUILDPLATFORM gcr.io/distroless/static:latest
 ARG TARGETARCH
 
 WORKDIR /run


### PR DESCRIPTION
The nonroot image does not have permission to write ebs volume. We can set the securityContext and change group, but it leads to permission mismatch to vllm image.