### PR TITLE
Generate TypeScript files from the protobuf with the `use_proto_names…

### DIFF
--- a/buf.gen.ts.yaml
+++ b/buf.gen.ts.yaml
@@ -2,3 +2,5 @@ version: v1
 plugins:
 - name: grpc-gateway-ts
   out: ./ts
+  opt:
+  - use_proto_names=true

--- a/dist/api/v1/inference_server.pb.d.ts
+++ b/dist/api/v1/inference_server.pb.d.ts
@@ -21,16 +21,16 @@ export type CreateChatCompletionRequestMessageContentAudioUrl = {
 export type CreateChatCompletionRequestMessageContent = {
     type?: string;
     text?: string;
-    imageUrl?: CreateChatCompletionRequestMessageContentImageUrl;
-    inputAudio?: CreateChatCompletionRequestMessageContentInputAudio;
-    audioUrl?: CreateChatCompletionRequestMessageContentAudioUrl;
+    image_url?: CreateChatCompletionRequestMessageContentImageUrl;
+    input_audio?: CreateChatCompletionRequestMessageContentInputAudio;
+    audio_url?: CreateChatCompletionRequestMessageContentAudioUrl;
 };
 export type CreateChatCompletionRequestMessage = {
     content?: CreateChatCompletionRequestMessageContent[];
     role?: string;
     name?: string;
-    toolCalls?: CreateChatCompletionRequestMessageToolCall[];
-    toolCallId?: string;
+    tool_calls?: CreateChatCompletionRequestMessageToolCall[];
+    tool_call_id?: string;
 };
 export type CreateChatCompletionRequestToolChoiceFunction = {
     name?: string;
@@ -45,39 +45,39 @@ export type CreateChatCompletionRequestResponseFormat = {
 export type CreateChatCompletionRequestToolFunction = {
     description?: string;
     name?: string;
-    encodedParameters?: string;
+    encoded_parameters?: string;
 };
 export type CreateChatCompletionRequestTool = {
     type?: string;
     function?: CreateChatCompletionRequestToolFunction;
 };
 export type CreateChatCompletionRequestStreamOptions = {
-    includeUsage?: boolean;
+    include_usage?: boolean;
 };
 export type CreateChatCompletionRequest = {
     messages?: CreateChatCompletionRequestMessage[];
     model?: string;
-    frequencyPenalty?: number;
-    logitBias?: {
+    frequency_penalty?: number;
+    logit_bias?: {
         [key: string]: number;
     };
     logprobs?: boolean;
-    topLogprobs?: number;
-    maxTokens?: number;
+    top_logprobs?: number;
+    max_tokens?: number;
     n?: number;
-    presencePenalty?: number;
-    responseFormat?: CreateChatCompletionRequestResponseFormat;
+    presence_penalty?: number;
+    response_format?: CreateChatCompletionRequestResponseFormat;
     seed?: number;
     stop?: string[];
     stream?: boolean;
-    streamOptions?: CreateChatCompletionRequestStreamOptions;
+    stream_options?: CreateChatCompletionRequestStreamOptions;
     temperature?: number;
-    topP?: number;
+    top_p?: number;
     tools?: CreateChatCompletionRequestTool[];
-    toolChoice?: string;
-    toolChoiceObject?: CreateChatCompletionRequestToolChoice;
+    tool_choice?: string;
+    tool_choice_object?: CreateChatCompletionRequestToolChoice;
     user?: string;
-    maxCompletionTokens?: number;
+    max_completion_tokens?: number;
 };
 export type ToolCallFunction = {
     name?: string;
@@ -97,23 +97,23 @@ export type LogprobsContent = {
     token?: string;
     logprob?: number;
     bytes?: Uint8Array;
-    topLogprobs?: LogprobsContentTopLogprobs;
+    top_logprobs?: LogprobsContentTopLogprobs;
 };
 export type Logprobs = {
     content?: LogprobsContent[];
 };
 export type Usage = {
-    completionTokens?: number;
-    promptTokens?: number;
-    totalTokens?: number;
+    completion_tokens?: number;
+    prompt_tokens?: number;
+    total_tokens?: number;
 };
 export type ChatCompletionChoiceMessage = {
     content?: string;
-    toolCalls?: ToolCall[];
+    tool_calls?: ToolCall[];
     role?: string;
 };
 export type ChatCompletionChoice = {
-    finishReason?: string;
+    finish_reason?: string;
     index?: number;
     message?: ChatCompletionChoiceMessage;
     logprobs?: Logprobs;
@@ -123,7 +123,7 @@ export type ChatCompletion = {
     choices?: ChatCompletionChoice[];
     created?: number;
     model?: string;
-    systemFingerprint?: string;
+    system_fingerprint?: string;
     object?: string;
     usage?: Usage;
 };
@@ -138,12 +138,12 @@ export type ChatCompletionChunkChoiceDeltaToolCall = {
 };
 export type ChatCompletionChunkChoiceDelta = {
     content?: string;
-    toolCalls?: ChatCompletionChunkChoiceDeltaToolCall[];
+    tool_calls?: ChatCompletionChunkChoiceDeltaToolCall[];
     role?: string;
 };
 export type ChatCompletionChunkChoice = {
     delta?: ChatCompletionChunkChoiceDelta;
-    finishReason?: string;
+    finish_reason?: string;
     index?: number;
     logprobs?: Logprobs;
 };
@@ -152,46 +152,46 @@ export type ChatCompletionChunk = {
     choices?: ChatCompletionChunkChoice[];
     created?: number;
     model?: string;
-    systemFingerprint?: string;
+    system_fingerprint?: string;
     object?: string;
     usage?: Usage;
 };
 export type RagFunction = {
-    vectorStoreName?: string;
+    vector_store_name?: string;
 };
 export type CreateCompletionRequestStreamOption = {
-    includeUsage?: boolean;
+    include_usage?: boolean;
 };
 export type CreateCompletionRequest = {
     model?: string;
     prompt?: string;
-    bestOf?: number;
+    best_of?: number;
     echo?: boolean;
-    frequencyPenalty?: number;
-    logitBias?: {
+    frequency_penalty?: number;
+    logit_bias?: {
         [key: string]: number;
     };
     logprobs?: number;
-    maxTokens?: number;
+    max_tokens?: number;
     n?: number;
-    presencePenalty?: number;
+    presence_penalty?: number;
     seed?: number;
     stop?: string[];
     stream?: boolean;
-    streamOption?: CreateCompletionRequestStreamOption;
+    stream_option?: CreateCompletionRequestStreamOption;
     suffix?: string;
     temperature?: number;
-    topP?: number;
+    top_p?: number;
     user?: string;
 };
 export type CompletionChoiceLogprobs = {
-    textOffset?: number;
-    tokenLogprobs?: number;
+    text_offset?: number;
+    token_logprobs?: number;
     tokens?: string;
-    topLogprobs?: number;
+    top_logprobs?: number;
 };
 export type CompletionChoice = {
-    finishReason?: string;
+    finish_reason?: string;
     index?: number;
     logprobs?: CompletionChoiceLogprobs;
     text?: string;
@@ -201,7 +201,7 @@ export type Completion = {
     choices?: CompletionChoice[];
     created?: number;
     model?: string;
-    systemFingerprint?: string;
+    system_fingerprint?: string;
     object?: string;
     usage?: Usage;
 };

--- a/dist/api/v1/inference_server_embeddings.pb.d.ts
+++ b/dist/api/v1/inference_server_embeddings.pb.d.ts
@@ -1,8 +1,8 @@
 export type CreateEmbeddingRequest = {
     input?: string;
-    encodedInput?: string;
+    encoded_input?: string;
     model?: string;
-    encodingFormat?: string;
+    encoding_format?: string;
     dimensions?: number;
     user?: string;
 };
@@ -12,8 +12,8 @@ export type Embedding = {
     object?: string;
 };
 export type EmbeddingsUsage = {
-    promptTokens?: number;
-    totalTokens?: number;
+    prompt_tokens?: number;
+    total_tokens?: number;
 };
 export type Embeddings = {
     object?: string;

--- a/dist/api/v1/inference_server_internal.pb.d.ts
+++ b/dist/api/v1/inference_server_internal.pb.d.ts
@@ -8,21 +8,21 @@ type OneOf<T> = {
     [k in K]: T[K];
 } & Absent<T, K> : never) : never);
 export type ServerStatusEngineStatusWithTenantID = {
-    engineStatus?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus;
-    tenantId?: string;
+    engine_status?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus;
+    tenant_id?: string;
 };
 export type ServerStatus = {
-    podName?: string;
-    engineStatuses?: ServerStatusEngineStatusWithTenantID[];
+    pod_name?: string;
+    engine_statuses?: ServerStatusEngineStatusWithTenantID[];
 };
 type BaseProcessTasksInternalRequest = {};
 export type ProcessTasksInternalRequest = BaseProcessTasksInternalRequest & OneOf<{
-    serverStatus: ServerStatus;
-    taskResult: LlmarinerInferenceServerV1Inference_server_worker.TaskResult;
+    server_status: ServerStatus;
+    task_result: LlmarinerInferenceServerV1Inference_server_worker.TaskResult;
 }>;
 export type ProcessTasksInternalResponse = {
-    newTask?: LlmarinerInferenceServerV1Inference_server_worker.Task;
-    tenantId?: string;
+    new_task?: LlmarinerInferenceServerV1Inference_server_worker.Task;
+    tenant_id?: string;
 };
 export declare class InferenceInternalService {
 }

--- a/dist/api/v1/inference_server_status.pb.d.ts
+++ b/dist/api/v1/inference_server_status.pb.d.ts
@@ -1,21 +1,21 @@
 import * as fm from "../../fetch.pb";
 import * as LlmarinerInferenceServerV1Inference_server_worker from "./inference_server_worker.pb";
 export type InferenceStatus = {
-    clusterStatuses?: ClusterStatus[];
-    taskStatus?: TaskStatus;
+    cluster_statuses?: ClusterStatus[];
+    task_status?: TaskStatus;
 };
 export type TaskStatus = {
-    inProgressTaskCounts?: {
+    in_progress_task_counts?: {
         [key: string]: number;
     };
 };
 export type ClusterStatus = {
     id?: string;
     name?: string;
-    engineStatuses?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus[];
-    modelCount?: number;
-    inProgressTaskCount?: number;
-    gpuAllocated?: number;
+    engine_statuses?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus[];
+    model_count?: number;
+    in_progress_task_count?: number;
+    gpu_allocated?: number;
 };
 export type GetInferenceStatusRequest = {};
 export declare class InferenceService {

--- a/dist/api/v1/inference_server_worker.pb.d.ts
+++ b/dist/api/v1/inference_server_worker.pb.d.ts
@@ -9,27 +9,27 @@ type OneOf<T> = {
     [k in K]: T[K];
 } & Absent<T, K> : never) : never);
 export type EngineStatusSyncStatus = {
-    inProgressModelIds?: string[];
+    in_progress_model_ids?: string[];
 };
 export type EngineStatusModel = {
     id?: string;
-    isReady?: boolean;
-    inProgressTaskCount?: number;
-    gpuAllocated?: number;
+    is_ready?: boolean;
+    in_progress_task_count?: number;
+    gpu_allocated?: number;
 };
 export type EngineStatus = {
-    engineId?: string;
-    modelIds?: string[];
-    syncStatus?: EngineStatusSyncStatus;
+    engine_id?: string;
+    model_ids?: string[];
+    sync_status?: EngineStatusSyncStatus;
     ready?: boolean;
     models?: EngineStatusModel[];
-    clusterId?: string;
+    cluster_id?: string;
 };
 export type HeaderValue = {
     values?: string[];
 };
 export type HttpResponse = {
-    statusCode?: number;
+    status_code?: number;
     status?: string;
     header?: {
         [key: string]: HeaderValue;
@@ -38,23 +38,23 @@ export type HttpResponse = {
 };
 export type ServerSentEvent = {
     data?: Uint8Array;
-    isLastEvent?: boolean;
+    is_last_event?: boolean;
 };
 type BaseTaskResult = {
-    taskId?: string;
+    task_id?: string;
 };
 export type TaskResult = BaseTaskResult & OneOf<{
-    httpResponse: HttpResponse;
-    serverSentEvent: ServerSentEvent;
+    http_response: HttpResponse;
+    server_sent_event: ServerSentEvent;
 }>;
 type BaseProcessTasksRequest = {};
 export type ProcessTasksRequest = BaseProcessTasksRequest & OneOf<{
-    engineStatus: EngineStatus;
-    taskResult: TaskResult;
+    engine_status: EngineStatus;
+    task_result: TaskResult;
 }>;
 type BaseTaskRequest = {};
 export type TaskRequest = BaseTaskRequest & OneOf<{
-    chatCompletion: LlmarinerChatServerV1Inference_server.CreateChatCompletionRequest;
+    chat_completion: LlmarinerChatServerV1Inference_server.CreateChatCompletionRequest;
     embedding: LlmarinerEmbeddingsServerV1Inference_server_embeddings.CreateEmbeddingRequest;
 }>;
 export type Task = {
@@ -65,7 +65,7 @@ export type Task = {
     };
 };
 export type ProcessTasksResponse = {
-    newTask?: Task;
+    new_task?: Task;
 };
 export declare class InferenceWorkerService {
 }

--- a/ts/api/v1/inference_server.pb.ts
+++ b/ts/api/v1/inference_server.pb.ts
@@ -31,17 +31,17 @@ export type CreateChatCompletionRequestMessageContentAudioUrl = {
 export type CreateChatCompletionRequestMessageContent = {
   type?: string
   text?: string
-  imageUrl?: CreateChatCompletionRequestMessageContentImageUrl
-  inputAudio?: CreateChatCompletionRequestMessageContentInputAudio
-  audioUrl?: CreateChatCompletionRequestMessageContentAudioUrl
+  image_url?: CreateChatCompletionRequestMessageContentImageUrl
+  input_audio?: CreateChatCompletionRequestMessageContentInputAudio
+  audio_url?: CreateChatCompletionRequestMessageContentAudioUrl
 }
 
 export type CreateChatCompletionRequestMessage = {
   content?: CreateChatCompletionRequestMessageContent[]
   role?: string
   name?: string
-  toolCalls?: CreateChatCompletionRequestMessageToolCall[]
-  toolCallId?: string
+  tool_calls?: CreateChatCompletionRequestMessageToolCall[]
+  tool_call_id?: string
 }
 
 export type CreateChatCompletionRequestToolChoiceFunction = {
@@ -60,7 +60,7 @@ export type CreateChatCompletionRequestResponseFormat = {
 export type CreateChatCompletionRequestToolFunction = {
   description?: string
   name?: string
-  encodedParameters?: string
+  encoded_parameters?: string
 }
 
 export type CreateChatCompletionRequestTool = {
@@ -69,31 +69,31 @@ export type CreateChatCompletionRequestTool = {
 }
 
 export type CreateChatCompletionRequestStreamOptions = {
-  includeUsage?: boolean
+  include_usage?: boolean
 }
 
 export type CreateChatCompletionRequest = {
   messages?: CreateChatCompletionRequestMessage[]
   model?: string
-  frequencyPenalty?: number
-  logitBias?: {[key: string]: number}
+  frequency_penalty?: number
+  logit_bias?: {[key: string]: number}
   logprobs?: boolean
-  topLogprobs?: number
-  maxTokens?: number
+  top_logprobs?: number
+  max_tokens?: number
   n?: number
-  presencePenalty?: number
-  responseFormat?: CreateChatCompletionRequestResponseFormat
+  presence_penalty?: number
+  response_format?: CreateChatCompletionRequestResponseFormat
   seed?: number
   stop?: string[]
   stream?: boolean
-  streamOptions?: CreateChatCompletionRequestStreamOptions
+  stream_options?: CreateChatCompletionRequestStreamOptions
   temperature?: number
-  topP?: number
+  top_p?: number
   tools?: CreateChatCompletionRequestTool[]
-  toolChoice?: string
-  toolChoiceObject?: CreateChatCompletionRequestToolChoice
+  tool_choice?: string
+  tool_choice_object?: CreateChatCompletionRequestToolChoice
   user?: string
-  maxCompletionTokens?: number
+  max_completion_tokens?: number
 }
 
 export type ToolCallFunction = {
@@ -117,7 +117,7 @@ export type LogprobsContent = {
   token?: string
   logprob?: number
   bytes?: Uint8Array
-  topLogprobs?: LogprobsContentTopLogprobs
+  top_logprobs?: LogprobsContentTopLogprobs
 }
 
 export type Logprobs = {
@@ -125,19 +125,19 @@ export type Logprobs = {
 }
 
 export type Usage = {
-  completionTokens?: number
-  promptTokens?: number
-  totalTokens?: number
+  completion_tokens?: number
+  prompt_tokens?: number
+  total_tokens?: number
 }
 
 export type ChatCompletionChoiceMessage = {
   content?: string
-  toolCalls?: ToolCall[]
+  tool_calls?: ToolCall[]
   role?: string
 }
 
 export type ChatCompletionChoice = {
-  finishReason?: string
+  finish_reason?: string
   index?: number
   message?: ChatCompletionChoiceMessage
   logprobs?: Logprobs
@@ -148,7 +148,7 @@ export type ChatCompletion = {
   choices?: ChatCompletionChoice[]
   created?: number
   model?: string
-  systemFingerprint?: string
+  system_fingerprint?: string
   object?: string
   usage?: Usage
 }
@@ -166,13 +166,13 @@ export type ChatCompletionChunkChoiceDeltaToolCall = {
 
 export type ChatCompletionChunkChoiceDelta = {
   content?: string
-  toolCalls?: ChatCompletionChunkChoiceDeltaToolCall[]
+  tool_calls?: ChatCompletionChunkChoiceDeltaToolCall[]
   role?: string
 }
 
 export type ChatCompletionChunkChoice = {
   delta?: ChatCompletionChunkChoiceDelta
-  finishReason?: string
+  finish_reason?: string
   index?: number
   logprobs?: Logprobs
 }
@@ -182,49 +182,49 @@ export type ChatCompletionChunk = {
   choices?: ChatCompletionChunkChoice[]
   created?: number
   model?: string
-  systemFingerprint?: string
+  system_fingerprint?: string
   object?: string
   usage?: Usage
 }
 
 export type RagFunction = {
-  vectorStoreName?: string
+  vector_store_name?: string
 }
 
 export type CreateCompletionRequestStreamOption = {
-  includeUsage?: boolean
+  include_usage?: boolean
 }
 
 export type CreateCompletionRequest = {
   model?: string
   prompt?: string
-  bestOf?: number
+  best_of?: number
   echo?: boolean
-  frequencyPenalty?: number
-  logitBias?: {[key: string]: number}
+  frequency_penalty?: number
+  logit_bias?: {[key: string]: number}
   logprobs?: number
-  maxTokens?: number
+  max_tokens?: number
   n?: number
-  presencePenalty?: number
+  presence_penalty?: number
   seed?: number
   stop?: string[]
   stream?: boolean
-  streamOption?: CreateCompletionRequestStreamOption
+  stream_option?: CreateCompletionRequestStreamOption
   suffix?: string
   temperature?: number
-  topP?: number
+  top_p?: number
   user?: string
 }
 
 export type CompletionChoiceLogprobs = {
-  textOffset?: number
-  tokenLogprobs?: number
+  text_offset?: number
+  token_logprobs?: number
   tokens?: string
-  topLogprobs?: number
+  top_logprobs?: number
 }
 
 export type CompletionChoice = {
-  finishReason?: string
+  finish_reason?: string
   index?: number
   logprobs?: CompletionChoiceLogprobs
   text?: string
@@ -235,7 +235,7 @@ export type Completion = {
   choices?: CompletionChoice[]
   created?: number
   model?: string
-  systemFingerprint?: string
+  system_fingerprint?: string
   object?: string
   usage?: Usage
 }

--- a/ts/api/v1/inference_server_embeddings.pb.ts
+++ b/ts/api/v1/inference_server_embeddings.pb.ts
@@ -5,9 +5,9 @@
 */
 export type CreateEmbeddingRequest = {
   input?: string
-  encodedInput?: string
+  encoded_input?: string
   model?: string
-  encodingFormat?: string
+  encoding_format?: string
   dimensions?: number
   user?: string
 }
@@ -19,8 +19,8 @@ export type Embedding = {
 }
 
 export type EmbeddingsUsage = {
-  promptTokens?: number
-  totalTokens?: number
+  prompt_tokens?: number
+  total_tokens?: number
 }
 
 export type Embeddings = {

--- a/ts/api/v1/inference_server_internal.pb.ts
+++ b/ts/api/v1/inference_server_internal.pb.ts
@@ -15,13 +15,13 @@ type OneOf<T> =
         : never)
     : never);
 export type ServerStatusEngineStatusWithTenantID = {
-  engineStatus?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus
-  tenantId?: string
+  engine_status?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus
+  tenant_id?: string
 }
 
 export type ServerStatus = {
-  podName?: string
-  engineStatuses?: ServerStatusEngineStatusWithTenantID[]
+  pod_name?: string
+  engine_statuses?: ServerStatusEngineStatusWithTenantID[]
 }
 
 
@@ -29,11 +29,11 @@ type BaseProcessTasksInternalRequest = {
 }
 
 export type ProcessTasksInternalRequest = BaseProcessTasksInternalRequest
-  & OneOf<{ serverStatus: ServerStatus; taskResult: LlmarinerInferenceServerV1Inference_server_worker.TaskResult }>
+  & OneOf<{ server_status: ServerStatus; task_result: LlmarinerInferenceServerV1Inference_server_worker.TaskResult }>
 
 export type ProcessTasksInternalResponse = {
-  newTask?: LlmarinerInferenceServerV1Inference_server_worker.Task
-  tenantId?: string
+  new_task?: LlmarinerInferenceServerV1Inference_server_worker.Task
+  tenant_id?: string
 }
 
 export class InferenceInternalService {

--- a/ts/api/v1/inference_server_status.pb.ts
+++ b/ts/api/v1/inference_server_status.pb.ts
@@ -7,21 +7,21 @@
 import * as fm from "../../fetch.pb"
 import * as LlmarinerInferenceServerV1Inference_server_worker from "./inference_server_worker.pb"
 export type InferenceStatus = {
-  clusterStatuses?: ClusterStatus[]
-  taskStatus?: TaskStatus
+  cluster_statuses?: ClusterStatus[]
+  task_status?: TaskStatus
 }
 
 export type TaskStatus = {
-  inProgressTaskCounts?: {[key: string]: number}
+  in_progress_task_counts?: {[key: string]: number}
 }
 
 export type ClusterStatus = {
   id?: string
   name?: string
-  engineStatuses?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus[]
-  modelCount?: number
-  inProgressTaskCount?: number
-  gpuAllocated?: number
+  engine_statuses?: LlmarinerInferenceServerV1Inference_server_worker.EngineStatus[]
+  model_count?: number
+  in_progress_task_count?: number
+  gpu_allocated?: number
 }
 
 export type GetInferenceStatusRequest = {

--- a/ts/api/v1/inference_server_worker.pb.ts
+++ b/ts/api/v1/inference_server_worker.pb.ts
@@ -16,23 +16,23 @@ type OneOf<T> =
         : never)
     : never);
 export type EngineStatusSyncStatus = {
-  inProgressModelIds?: string[]
+  in_progress_model_ids?: string[]
 }
 
 export type EngineStatusModel = {
   id?: string
-  isReady?: boolean
-  inProgressTaskCount?: number
-  gpuAllocated?: number
+  is_ready?: boolean
+  in_progress_task_count?: number
+  gpu_allocated?: number
 }
 
 export type EngineStatus = {
-  engineId?: string
-  modelIds?: string[]
-  syncStatus?: EngineStatusSyncStatus
+  engine_id?: string
+  model_ids?: string[]
+  sync_status?: EngineStatusSyncStatus
   ready?: boolean
   models?: EngineStatusModel[]
-  clusterId?: string
+  cluster_id?: string
 }
 
 export type HeaderValue = {
@@ -40,7 +40,7 @@ export type HeaderValue = {
 }
 
 export type HttpResponse = {
-  statusCode?: number
+  status_code?: number
   status?: string
   header?: {[key: string]: HeaderValue}
   body?: Uint8Array
@@ -48,30 +48,30 @@ export type HttpResponse = {
 
 export type ServerSentEvent = {
   data?: Uint8Array
-  isLastEvent?: boolean
+  is_last_event?: boolean
 }
 
 
 type BaseTaskResult = {
-  taskId?: string
+  task_id?: string
 }
 
 export type TaskResult = BaseTaskResult
-  & OneOf<{ httpResponse: HttpResponse; serverSentEvent: ServerSentEvent }>
+  & OneOf<{ http_response: HttpResponse; server_sent_event: ServerSentEvent }>
 
 
 type BaseProcessTasksRequest = {
 }
 
 export type ProcessTasksRequest = BaseProcessTasksRequest
-  & OneOf<{ engineStatus: EngineStatus; taskResult: TaskResult }>
+  & OneOf<{ engine_status: EngineStatus; task_result: TaskResult }>
 
 
 type BaseTaskRequest = {
 }
 
 export type TaskRequest = BaseTaskRequest
-  & OneOf<{ chatCompletion: LlmarinerChatServerV1Inference_server.CreateChatCompletionRequest; embedding: LlmarinerEmbeddingsServerV1Inference_server_embeddings.CreateEmbeddingRequest }>
+  & OneOf<{ chat_completion: LlmarinerChatServerV1Inference_server.CreateChatCompletionRequest; embedding: LlmarinerEmbeddingsServerV1Inference_server_embeddings.CreateEmbeddingRequest }>
 
 export type Task = {
   id?: string
@@ -80,7 +80,7 @@ export type Task = {
 }
 
 export type ProcessTasksResponse = {
-  newTask?: Task
+  new_task?: Task
 }
 
 export class InferenceWorkerService {

--- a/ts/google/api/http.pb.ts
+++ b/ts/google/api/http.pb.ts
@@ -14,15 +14,15 @@ type OneOf<T> =
     : never);
 export type Http = {
   rules?: HttpRule[]
-  fullyDecodeReservedExpansion?: boolean
+  fully_decode_reserved_expansion?: boolean
 }
 
 
 type BaseHttpRule = {
   selector?: string
   body?: string
-  responseBody?: string
-  additionalBindings?: HttpRule[]
+  response_body?: string
+  additional_bindings?: HttpRule[]
 }
 
 export type HttpRule = BaseHttpRule

--- a/ts/google/protobuf/descriptor.pb.ts
+++ b/ts/google/protobuf/descriptor.pb.ts
@@ -145,14 +145,14 @@ export type FileDescriptorProto = {
   name?: string
   package?: string
   dependency?: string[]
-  publicDependency?: number[]
-  weakDependency?: number[]
-  messageType?: DescriptorProto[]
-  enumType?: EnumDescriptorProto[]
+  public_dependency?: number[]
+  weak_dependency?: number[]
+  message_type?: DescriptorProto[]
+  enum_type?: EnumDescriptorProto[]
   service?: ServiceDescriptorProto[]
   extension?: FieldDescriptorProto[]
   options?: FileOptions
-  sourceCodeInfo?: SourceCodeInfo
+  source_code_info?: SourceCodeInfo
   syntax?: string
   edition?: Edition
 }
@@ -172,25 +172,25 @@ export type DescriptorProto = {
   name?: string
   field?: FieldDescriptorProto[]
   extension?: FieldDescriptorProto[]
-  nestedType?: DescriptorProto[]
-  enumType?: EnumDescriptorProto[]
-  extensionRange?: DescriptorProtoExtensionRange[]
-  oneofDecl?: OneofDescriptorProto[]
+  nested_type?: DescriptorProto[]
+  enum_type?: EnumDescriptorProto[]
+  extension_range?: DescriptorProtoExtensionRange[]
+  oneof_decl?: OneofDescriptorProto[]
   options?: MessageOptions
-  reservedRange?: DescriptorProtoReservedRange[]
-  reservedName?: string[]
+  reserved_range?: DescriptorProtoReservedRange[]
+  reserved_name?: string[]
 }
 
 export type ExtensionRangeOptionsDeclaration = {
   number?: number
-  fullName?: string
+  full_name?: string
   type?: string
   reserved?: boolean
   repeated?: boolean
 }
 
 export type ExtensionRangeOptions = {
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
   declaration?: ExtensionRangeOptionsDeclaration[]
   features?: FeatureSet
   verification?: ExtensionRangeOptionsVerificationState
@@ -201,13 +201,13 @@ export type FieldDescriptorProto = {
   number?: number
   label?: FieldDescriptorProtoLabel
   type?: FieldDescriptorProtoType
-  typeName?: string
+  type_name?: string
   extendee?: string
-  defaultValue?: string
-  oneofIndex?: number
-  jsonName?: string
+  default_value?: string
+  oneof_index?: number
+  json_name?: string
   options?: FieldOptions
-  proto3Optional?: boolean
+  proto3_optional?: boolean
 }
 
 export type OneofDescriptorProto = {
@@ -224,8 +224,8 @@ export type EnumDescriptorProto = {
   name?: string
   value?: EnumValueDescriptorProto[]
   options?: EnumOptions
-  reservedRange?: EnumDescriptorProtoEnumReservedRange[]
-  reservedName?: string[]
+  reserved_range?: EnumDescriptorProtoEnumReservedRange[]
+  reserved_name?: string[]
 }
 
 export type EnumValueDescriptorProto = {
@@ -242,45 +242,45 @@ export type ServiceDescriptorProto = {
 
 export type MethodDescriptorProto = {
   name?: string
-  inputType?: string
-  outputType?: string
+  input_type?: string
+  output_type?: string
   options?: MethodOptions
-  clientStreaming?: boolean
-  serverStreaming?: boolean
+  client_streaming?: boolean
+  server_streaming?: boolean
 }
 
 export type FileOptions = {
-  javaPackage?: string
-  javaOuterClassname?: string
-  javaMultipleFiles?: boolean
-  javaGenerateEqualsAndHash?: boolean
-  javaStringCheckUtf8?: boolean
-  optimizeFor?: FileOptionsOptimizeMode
-  goPackage?: string
-  ccGenericServices?: boolean
-  javaGenericServices?: boolean
-  pyGenericServices?: boolean
+  java_package?: string
+  java_outer_classname?: string
+  java_multiple_files?: boolean
+  java_generate_equals_and_hash?: boolean
+  java_string_check_utf8?: boolean
+  optimize_for?: FileOptionsOptimizeMode
+  go_package?: string
+  cc_generic_services?: boolean
+  java_generic_services?: boolean
+  py_generic_services?: boolean
   deprecated?: boolean
-  ccEnableArenas?: boolean
-  objcClassPrefix?: string
-  csharpNamespace?: string
-  swiftPrefix?: string
-  phpClassPrefix?: string
-  phpNamespace?: string
-  phpMetadataNamespace?: string
-  rubyPackage?: string
+  cc_enable_arenas?: boolean
+  objc_class_prefix?: string
+  csharp_namespace?: string
+  swift_prefix?: string
+  php_class_prefix?: string
+  php_namespace?: string
+  php_metadata_namespace?: string
+  ruby_package?: string
   features?: FeatureSet
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type MessageOptions = {
-  messageSetWireFormat?: boolean
-  noStandardDescriptorAccessor?: boolean
+  message_set_wire_format?: boolean
+  no_standard_descriptor_accessor?: boolean
   deprecated?: boolean
-  mapEntry?: boolean
-  deprecatedLegacyJsonFieldConflicts?: boolean
+  map_entry?: boolean
+  deprecated_legacy_json_field_conflicts?: boolean
   features?: FeatureSet
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type FieldOptionsEditionDefault = {
@@ -289,10 +289,10 @@ export type FieldOptionsEditionDefault = {
 }
 
 export type FieldOptionsFeatureSupport = {
-  editionIntroduced?: Edition
-  editionDeprecated?: Edition
-  deprecationWarning?: string
-  editionRemoved?: Edition
+  edition_introduced?: Edition
+  edition_deprecated?: Edition
+  deprecation_warning?: string
+  edition_removed?: Edition
 }
 
 export type FieldOptions = {
@@ -300,94 +300,94 @@ export type FieldOptions = {
   packed?: boolean
   jstype?: FieldOptionsJSType
   lazy?: boolean
-  unverifiedLazy?: boolean
+  unverified_lazy?: boolean
   deprecated?: boolean
   weak?: boolean
-  debugRedact?: boolean
+  debug_redact?: boolean
   retention?: FieldOptionsOptionRetention
   targets?: FieldOptionsOptionTargetType[]
-  editionDefaults?: FieldOptionsEditionDefault[]
+  edition_defaults?: FieldOptionsEditionDefault[]
   features?: FeatureSet
-  featureSupport?: FieldOptionsFeatureSupport
-  uninterpretedOption?: UninterpretedOption[]
+  feature_support?: FieldOptionsFeatureSupport
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type OneofOptions = {
   features?: FeatureSet
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type EnumOptions = {
-  allowAlias?: boolean
+  allow_alias?: boolean
   deprecated?: boolean
-  deprecatedLegacyJsonFieldConflicts?: boolean
+  deprecated_legacy_json_field_conflicts?: boolean
   features?: FeatureSet
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type EnumValueOptions = {
   deprecated?: boolean
   features?: FeatureSet
-  debugRedact?: boolean
-  featureSupport?: FieldOptionsFeatureSupport
-  uninterpretedOption?: UninterpretedOption[]
+  debug_redact?: boolean
+  feature_support?: FieldOptionsFeatureSupport
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type ServiceOptions = {
   features?: FeatureSet
   deprecated?: boolean
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type MethodOptions = {
   deprecated?: boolean
-  idempotencyLevel?: MethodOptionsIdempotencyLevel
+  idempotency_level?: MethodOptionsIdempotencyLevel
   features?: FeatureSet
-  uninterpretedOption?: UninterpretedOption[]
+  uninterpreted_option?: UninterpretedOption[]
 }
 
 export type UninterpretedOptionNamePart = {
-  namePart?: string
-  isExtension?: boolean
+  name_part?: string
+  is_extension?: boolean
 }
 
 export type UninterpretedOption = {
   name?: UninterpretedOptionNamePart[]
-  identifierValue?: string
-  positiveIntValue?: string
-  negativeIntValue?: string
-  doubleValue?: number
-  stringValue?: Uint8Array
-  aggregateValue?: string
+  identifier_value?: string
+  positive_int_value?: string
+  negative_int_value?: string
+  double_value?: number
+  string_value?: Uint8Array
+  aggregate_value?: string
 }
 
 export type FeatureSet = {
-  fieldPresence?: FeatureSetFieldPresence
-  enumType?: FeatureSetEnumType
-  repeatedFieldEncoding?: FeatureSetRepeatedFieldEncoding
-  utf8Validation?: FeatureSetUtf8Validation
-  messageEncoding?: FeatureSetMessageEncoding
-  jsonFormat?: FeatureSetJsonFormat
+  field_presence?: FeatureSetFieldPresence
+  enum_type?: FeatureSetEnumType
+  repeated_field_encoding?: FeatureSetRepeatedFieldEncoding
+  utf8_validation?: FeatureSetUtf8Validation
+  message_encoding?: FeatureSetMessageEncoding
+  json_format?: FeatureSetJsonFormat
 }
 
 export type FeatureSetDefaultsFeatureSetEditionDefault = {
   edition?: Edition
-  overridableFeatures?: FeatureSet
-  fixedFeatures?: FeatureSet
+  overridable_features?: FeatureSet
+  fixed_features?: FeatureSet
 }
 
 export type FeatureSetDefaults = {
   defaults?: FeatureSetDefaultsFeatureSetEditionDefault[]
-  minimumEdition?: Edition
-  maximumEdition?: Edition
+  minimum_edition?: Edition
+  maximum_edition?: Edition
 }
 
 export type SourceCodeInfoLocation = {
   path?: number[]
   span?: number[]
-  leadingComments?: string
-  trailingComments?: string
-  leadingDetachedComments?: string[]
+  leading_comments?: string
+  trailing_comments?: string
+  leading_detached_comments?: string[]
 }
 
 export type SourceCodeInfo = {
@@ -396,7 +396,7 @@ export type SourceCodeInfo = {
 
 export type GeneratedCodeInfoAnnotation = {
   path?: number[]
-  sourceFile?: string
+  source_file?: string
   begin?: number
   end?: number
   semantic?: GeneratedCodeInfoAnnotationSemantic


### PR DESCRIPTION
…` option turned on

By default, `protoc-gen-grpc-gateway-ts` generates files with field names named by using the lower camel case.

Some of our servers are using gRPC-Gateway v2 with `UseProtoNames` set to `true`.
https://github.com/search?q=org%3Allmariner%20UseProtoNames&type=code

See also https://github.com/grpc-ecosystem/grpc-gateway/blob/2ee9ba58097ac79e34f3e63beef9358d4f24d2fd/docs/docs/development/grpc-gateway_v2_migration_guide.md#we-now-use-the-camelcase-json-names-by-default

To make the generated TypeScript files work with it, we need to use the `use_proto_names` option.
https://github.com/grpc-ecosystem/protoc-gen-grpc-gateway-ts?tab=readme-ov-file#use_proto_names

Currently, we're manually copying what's needed from generated files to `llmariner/frontend` repo (under the `src/next/types/` directory) after manually editing them to fix the naming convention. This manual editing step can be eliminated by just using the `use_proto_names` option.

From the beginning, maybe we can revisit the use of `UseProtoNames` option on the server side.

Note that I used Buf `v1.50.0` to run `make generate` which is different from https://github.com/llmariner/llmariner/blob/main/DEVELOPMENT.md#protocol-buffers.

See https://github.com/llmariner/inference-manager/pull/595#issue-2875189503 for the reason.