### PR TITLE
fix: fix LoRA serviing in vLLM

### DIFF
--- a/engine/internal/runtime/vllm_client_test.go
+++ b/engine/internal/runtime/vllm_client_test.go
@@ -131,7 +131,7 @@ func TestDeployRuntimeParams(t *testing.T) {
 			wantArgs: []string{
 				"--port", "80",
 				"--model", "/models/base-model0",
-				"--served-model-name", "TinyLlama-TinyLlama-1.1B-Chat-v1.0",
+				"--served-model-name", "base-model0",
 				"--chat-template", "\n<|begin_of_text|>\n{% for message in messages %}\n{{'<|start_header_id|>' + message['role'] + '<|end_header_id|>\\n' + message['content'] + '\\n<|eot_id|>\\n'}}\n{% endfor %}\n",
 				"--tensor-parallel-size", "2",
 				"--enable-lora",


### PR DESCRIPTION
When LoRA is used, set --served-model-name to the base model name ID, not to the fine-tuned model ID.  vLLM serves both the base model and the fined-tune model, and --served-model-name is used to specify the base model name.

See https://docs.vllm.ai/en/v0.5.5/models/lora.html#serving-lora-adapters.