### PR TITLE
fix(ci-post-merge.yml): run `softprops/action-gh-release` with the `target_commitish` option set

### DIFF
--- a/.github/workflows/ci-post-merge.yml
+++ b/.github/workflows/ci-post-merge.yml
@@ -133,4 +133,5 @@ jobs:
       uses: softprops/action-gh-release@v2.0.8
       with:
         tag_name: v${{ env.version }}
+        target_commitish: ${{ github.sha }}
         generate_release_notes: true


### PR DESCRIPTION
The tip of the default branch is not necessarily the commit that triggered this workflow. E.g. another commit can be pushed while this workflow is building container images, etc.