### PR TITLE
fix: do not use ExtractUserInfoFromContext

### DIFF
--- a/server/internal/rate/limiter.go
+++ b/server/internal/rate/limiter.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/llmariner/rbac-manager/pkg/auth"
 )
 
 // NewLimiter returns a new rate limiter.
@@ -34,19 +33,6 @@ type Limiter struct {
 
 // Take takes a token from the given key if available.
 func (l *Limiter) Take(ctx context.Context, key string) (*Result, error) {
-	// Check if the user is excluded from rate limiting
-	if userInfo, ok := auth.ExtractUserInfoFromContext(ctx); ok && userInfo.ExcludedFromRateLimiting {
-		// Create a result that indicates unlimited usage for excluded API keys
-		return &Result{
-			Allowed:    true,
-			Limit:      -1, // -1 indicates unlimited
-			Remaining:  -1, // -1 indicates unlimited
-			RetryAfter: 0,  // No retry needed
-			ResetAfter: 0,  // No reset
-		}, nil
-	}
-
-	// For all other cases, apply normal rate limiting
 	// TODO(aya): support inference-token limiter
 	return l.store.Take(ctx, key, 1)
 }

--- a/server/internal/server/completions.go
+++ b/server/internal/server/completions.go
@@ -64,15 +64,17 @@ func (s *S) CreateChatCompletion(
 		s.usageSetter.AddUsage(&usage)
 	}()
 
-	res, err := s.ratelimiter.Take(req.Context(), userInfo.APIKeyID)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	rate.SetRateLimitHTTPHeaders(w, res)
-	if !res.Allowed {
-		httpError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests, &usage)
-		return
+	if !userInfo.ExcludedFromRateLimiting {
+		res, err := s.ratelimiter.Take(req.Context(), userInfo.APIKeyID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rate.SetRateLimitHTTPHeaders(w, res)
+		if !res.Allowed {
+			httpError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests, &usage)
+			return
+		}
 	}
 
 	reqBody, err := io.ReadAll(req.Body)

--- a/server/internal/server/legacy_completions.go
+++ b/server/internal/server/legacy_completions.go
@@ -51,15 +51,17 @@ func (s *S) CreateCompletion(
 		s.usageSetter.AddUsage(&usage)
 	}()
 
-	res, err := s.ratelimiter.Take(req.Context(), userInfo.APIKeyID)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	rate.SetRateLimitHTTPHeaders(w, res)
-	if !res.Allowed {
-		httpError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests, &usage)
-		return
+	if !userInfo.ExcludedFromRateLimiting {
+		res, err := s.ratelimiter.Take(req.Context(), userInfo.APIKeyID)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		rate.SetRateLimitHTTPHeaders(w, res)
+		if !res.Allowed {
+			httpError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests, &usage)
+			return
+		}
 	}
 
 	reqBody, err := io.ReadAll(req.Body)


### PR DESCRIPTION
The function only works for gRPC endpoint, and
it doesn't work for HTTP handlers.