### PR TITLE
fix: correctly refresh the engine status cache

### DIFF
--- a/server/internal/taskexchanger/task_receiver.go
+++ b/server/internal/taskexchanger/task_receiver.go
@@ -218,18 +218,24 @@ func (r *taskReceiver) buildStatuses(ready bool) ([]*v1.ServerStatus_EngineStatu
 
 	var statuses []*v1.ServerStatus_EngineStatusWithTenantID
 	for tenantID, es := range enginesByTenantID {
-		updated := map[string]*v1.EngineStatus{}
 		for _, e := range es {
 			statuses = append(statuses, &v1.ServerStatus_EngineStatusWithTenantID{
 				EngineStatus: e,
 				TenantId:     tenantID,
 			})
-
-			updated[e.EngineId] = e
 		}
-
-		r.engineStatuses[tenantID] = updated
 	}
+
+	// Update the cached engine statuses.
+	newMap := make(map[string]map[string]*v1.EngineStatus)
+	for tenantID, es := range enginesByTenantID {
+		m := map[string]*v1.EngineStatus{}
+		for _, e := range es {
+			m[e.EngineId] = e
+		}
+		newMap[tenantID] = m
+	}
+	r.engineStatuses = newMap
 
 	return statuses, true, nil
 }


### PR DESCRIPTION
Recreate a map so that a tenant is removed from the map when there is no engine.