### PR TITLE
fix: do not always set --enable-lora

### DIFF
--- a/engine/internal/runtime/vllm_client.go
+++ b/engine/internal/runtime/vllm_client.go
@@ -129,9 +129,6 @@ func (v *vllmClient) deployRuntimeParams(ctx context.Context, modelID string) (d
 			"--served-model-name", oModelID,
 			"--model", mPath,
 		)
-		if v.vLLMConfig.DynamicLoRALoading {
-			args = append(args, "--enable-lora")
-		}
 	} else {
 		attr, err := v.modelClient.GetModelAttributes(ctx, &mv1.GetModelAttributesRequest{
 			Id: modelID,


### PR DESCRIPTION
Remove the logic that sets --enable-lora for all models when dynamic LoRA loading is enabled.

This doesn't work when a certain model (e.g., whisper) doesn't support LoRA (a VLLM pod will crash with --enable-lora).