### PR TITLE
fix: avoid duplicated name for the updater controller

### DIFF
--- a/engine/internal/runtime/updater.go
+++ b/engine/internal/runtime/updater.go
@@ -90,6 +90,7 @@ func (u *Updater) SetupWithManager(mgr ctrl.Manager) error {
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&appsv1.StatefulSet{}, builder.WithPredicates(filterByLabel)).
+		Named("runtime-updater").
 		Watches(&corev1.Pod{},
 			handler.TypedEnqueueRequestForOwner[client.Object](mgr.GetScheme(), mgr.GetRESTMapper(), &appsv1.StatefulSet{}, handler.OnlyControllerOwner()),
 			builder.WithPredicates(filterByLabel)).


### PR DESCRIPTION
Avoid the following error:

Error: controller with name statefulset already exists. Controller names must be unique to avoid multiple controllers reporting to the same metric