### PR TITLE
feat: add ingress for /v1/tokenize

### DIFF
--- a/deployments/server/templates/ingress.yaml
+++ b/deployments/server/templates/ingress.yaml
@@ -59,6 +59,13 @@ spec:
             name: {{ include "inference-manager-server.fullname" . }}-http
             port:
               number: {{ .Values.httpPort }}
+      - path: /v1/tokenize
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ include "inference-manager-server.fullname" . }}-http
+            port:
+              number: {{ .Values.httpPort }}
       - path: /v1/inference
         pathType: Prefix
         backend:


### PR DESCRIPTION
The vLLM endpoint doesn't have "v1", but we keep v1 for consistency.